### PR TITLE
docs: Update license references from MIT to GNU AGPL v3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,7 +248,7 @@ For implementation details, see:
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) for details.
+GNU AGPL v3 - See [LICENSE](LICENSE) for details.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ mise run validate  # Validate plugin
 
 ## License
 
-MIT License - [LICENSE](LICENSE)
+GNU AGPL v3 - [LICENSE](LICENSE)
 
 ## Related Resources
 


### PR DESCRIPTION
## Summary

Update license information in documentation files to reflect the license change from MIT to GNU AGPL v3.

## Changes

- CONTRIBUTING.md: Update license section
- README.md: Update license section

This aligns with the license change made in PR #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)