### PR TITLE
Fix: Correct directory path in note command

### DIFF
--- a/commands/note.md
+++ b/commands/note.md
@@ -36,7 +36,7 @@ If $ARGUMENTS is provided, execute the following:
 
 1. Execute with Bash tool:
    ```bash
-   mkdir -p .claude/as-you
+   mkdir -p .claude/as_you
    echo "[$(date +%H:%M)] $ARGUMENTS" >> .claude/as_you/session_notes.local.md
    ```
 2. Respond: "Note added"


### PR DESCRIPTION
## Summary
- `commands/note.md`内のディレクトリパスを修正：`.claude/as-you` → `.claude/as_you`
- ハイフン区切りからアンダースコア区切りに統一

## Test plan
- [ ] `/note`コマンドが正しく`.claude/as_you/session_notes.local.md`にメモを保存することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)