### PR TITLE
Fix: Use CLAUDE_PLUGIN_ROOT for script paths in commands

### DIFF
--- a/commands/memory.md
+++ b/commands/memory.md
@@ -13,7 +13,7 @@ Display memory statistics and analyze patterns.
 
    Execute statistics collection:
    ```bash
-   python3 scripts/commands/memory_stats.py
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/memory_stats.py"
    ```
 
 2. **Display Dashboard**
@@ -53,7 +53,7 @@ Display memory statistics and analyze patterns.
 4. **Execute Based on Selection**
 
    **If "View promotion candidates":**
-   - Execute: `python3 ./scripts/commands/promotion_analyzer.py`
+   - Execute: `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/promotion_analyzer.py"`
    - Display candidates with scores
    - Suggest: "Use /as-you:promote to create skill/agent"
 
@@ -66,10 +66,10 @@ Display memory statistics and analyze patterns.
      ```
 
    **If "Detect similar patterns":**
-   - Execute: `python3 scripts/commands/similarity_detector.py`
+   - Execute: `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/similarity_detector.py"`
    - Display similar pairs with Levenshtein distance
    - Ask if user wants to merge:
-     - If yes: Execute `python3 scripts/hooks/pattern_merger.py`
+     - If yes: Execute `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pattern_merger.py"`
      - If no: Return to menu
 
    **If "Review knowledge base":**

--- a/commands/note.md
+++ b/commands/note.md
@@ -31,7 +31,7 @@ If $ARGUMENTS is provided:
 
 2. Execute with Bash tool:
    ```bash
-   python3 scripts/commands/note_add.py "<translated-text>"
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/note_add.py" "<translated-text>"
    ```
    Replace `<translated-text>` with actual content from step 1.
 

--- a/commands/promote.md
+++ b/commands/promote.md
@@ -14,7 +14,7 @@ Promote a frequent pattern to knowledge base (Skill or Agent).
 
 Execute:
 ```bash
-python3 ./scripts/commands/promotion_analyzer.py
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/promotion_analyzer.py"
 ```
 
 If 0 candidates:
@@ -41,7 +41,7 @@ Analyze selected pattern to determine if it should be Skill or Agent:
 
 **Read pattern context:**
 ```bash
-python3 scripts/commands/pattern_context.py PATTERN_NAME
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/pattern_context.py" PATTERN_NAME
 ```
 
 **Analyze characteristics:**
@@ -107,7 +107,7 @@ Present generated component and ask:
 - Create file (skills/{name}/SKILL.md or agents/{name}.md)
 - Mark as promoted in pattern_tracker.json:
   ```bash
-  python3 scripts/lib/promotion_marker.py "PATTERN_NAME" {skill|agent} "{path}"
+  python3 "${CLAUDE_PLUGIN_ROOT}/scripts/lib/promotion_marker.py" "PATTERN_NAME" {skill|agent} "{path}"
   ```
 - Respond: "{Skill/Agent} created: {name}\n\nFile: {path}\n\nUse /as-you:memory to view updated stats"
 

--- a/commands/workflows.md
+++ b/commands/workflows.md
@@ -13,7 +13,7 @@ View and manage saved workflows.
 
 Execute to find user workflows (exclude built-in commands):
 ```bash
-python3 scripts/commands/workflow_list.py
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/workflow_list.py"
 ```
 
 If no workflows:


### PR DESCRIPTION
## Summary

- Fixed relative path issues in command definitions
- Commands now use `${CLAUDE_PLUGIN_ROOT}` environment variable for script paths
- Ensures commands work from any working directory

## Problem

Commands were using relative paths like `scripts/commands/note_add.py`, which failed when users executed commands from directories other than the plugin root:

```
Error: Exit code 2
can't open file '/Users/.../Project/other-project/scripts/commands/note_add.py': 
[Errno 2] No such file or directory
```

## Solution

Updated all command definitions to use `${CLAUDE_PLUGIN_ROOT}/scripts/...` instead of relative paths.

## Changed Files

- **commands/note.md**: `note_add.py`
- **commands/promote.md**: `promotion_analyzer.py`, `pattern_context.py`, `promotion_marker.py`
- **commands/memory.md**: `memory_stats.py`, `promotion_analyzer.py`, `similarity_detector.py`, `pattern_merger.py`
- **commands/workflows.md**: `workflow_list.py`

## Test Plan

- [x] Verified commands execute successfully from different working directories
- [x] No changes to script functionality, only path resolution
- [x] Hooks already use `${CLAUDE_PLUGIN_ROOT}` correctly

Generated with [Claude Code](https://claude.com/claude-code)