### PR TITLE
Fix: Use absolute paths for workspace file operations

### DIFF
--- a/agents/component-generator.md
+++ b/agents/component-generator.md
@@ -10,6 +10,10 @@ color: green
 
 You are a specialized agent for generating As You plugin components (Skills/Agents).
 
+## Important Note on File Paths
+
+ALWAYS use absolute paths for all file operations (Read, Write). The working directory will be provided in the prompt. Use `{working_directory}/.claude/as_you/...` format for all file paths.
+
 ## Responsibilities
 
 Generate appropriate skills or agents from memory patterns or user requirements.
@@ -19,7 +23,7 @@ Generate appropriate skills or agents from memory patterns or user requirements.
 ### For Skill Generation
 
 1. Understand skill name and purpose
-2. Reference patterns from `.claude/as_you/session_archive/` (if available)
+2. Reference patterns from `{working_directory}/.claude/as_you/session_archive/` using absolute path (if available)
 3. Generate SKILL.md with the following structure:
    ```markdown
    ---

--- a/agents/memory-analyzer.md
+++ b/agents/memory-analyzer.md
@@ -10,17 +10,22 @@ color: blue
 
 You are a specialized agent for analyzing As You plugin memory patterns.
 
+## Important Note on File Paths
+
+ALWAYS use absolute paths for all file operations. The working directory will be provided in the prompt. Use `{working_directory}/.claude/as_you/...` format for all file paths.
+
 ## Responsibilities
 
 Analyze pattern_tracker.json and suggest promotion of frequent patterns to knowledge base (Skills/Agents).
 
 ## Execution Steps
 
-1. Execute `python3 ./scripts/promotion_analyzer.py` using Bash tool to retrieve promotion candidates
-2. If 0 candidates:
+1. Get working directory with `pwd` using Bash tool
+2. Execute `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/commands/promotion_analyzer.py` using Bash tool to retrieve promotion candidates
+3. If 0 candidates:
    - Report: "No knowledge base promotion candidates currently available"
-   - Display current pattern count: `python3 -c "import json; print(len(json.load(open('.claude/as_you/pattern_tracker.json'))['patterns']))"`
-3. If candidates exist:
+   - Display current pattern count: `python3 -c "import json; print(len(json.load(open('{working_directory}/.claude/as_you/pattern_tracker.json'))['patterns']))"`
+4. If candidates exist:
    - Analyze details of each candidate
    - Report with priorities
    - Present concrete implementation ideas

--- a/agents/pattern-curator.md
+++ b/agents/pattern-curator.md
@@ -10,6 +10,10 @@ color: cyan
 
 You are a specialized agent for maintaining the quality and health of the As You plugin pattern database.
 
+## Important Note on File Paths
+
+ALWAYS use absolute paths for all file operations. Get the working directory with `pwd` first, then use `{working_directory}/.claude/as_you/...` format for all file paths.
+
 ## Responsibilities
 
 Maintain high-quality pattern data by:
@@ -22,7 +26,8 @@ Maintain high-quality pattern data by:
 ## Execution Steps
 
 1. **Load Pattern Database**
-   - Read `.claude/as_you/pattern_tracker.json`
+   - Get working directory with `pwd` using Bash tool
+   - Read `{working_directory}/.claude/as_you/pattern_tracker.json` using absolute path
    - Validate JSON structure
    - Count total patterns and metadata
 

--- a/commands/memory.md
+++ b/commands/memory.md
@@ -11,8 +11,9 @@ Display memory statistics and analyze patterns.
 
 1. **Collect Statistics**
 
-   Execute statistics collection:
+   Get current directory and execute statistics collection:
    ```bash
+   pwd
    python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/memory_stats.py"
    ```
 
@@ -61,7 +62,7 @@ Display memory statistics and analyze patterns.
    - Launch memory-analyzer agent using Task tool:
      ```
      subagent_type: "as-you:memory-analyzer"
-     prompt: "Analyze pattern_tracker.json and provide detailed promotion recommendations"
+     prompt: "Analyze pattern_tracker.json and provide detailed promotion recommendations. Working directory: {pwd} (use absolute paths)"
      description: "Analyze memory patterns"
      ```
 
@@ -73,7 +74,7 @@ Display memory statistics and analyze patterns.
      - If no: Return to menu
 
    **If "Review knowledge base":**
-   - Read `.claude/as_you/skill-usage-stats.json`
+   - Read `{pwd}/.claude/as_you/skill-usage-stats.json` using absolute path (where {pwd} is from step 1)
    - Identify unused skills/agents (30+ days)
    - Display recommendations
    - Ask about archiving unused items

--- a/commands/notes.md
+++ b/commands/notes.md
@@ -10,7 +10,8 @@ Display and manage session notes.
 ## Execution Steps
 
 1. **Display Current Session Notes**
-   - Read `.claude/as_you/session_notes.local.md`
+   - Get current directory: Execute `pwd` with Bash tool
+   - Read `{pwd}/.claude/as_you/session_notes.local.md` using absolute path
    - If empty or doesn't exist: "No notes in current session"
    - If exists: Display contents with line count
 
@@ -28,7 +29,7 @@ Display and manage session notes.
 3. **Execute Based on Selection**
 
    **If "View history":**
-   - Search `.claude/as_you/session_archive/*.md` using Glob
+   - Use Glob to search `{pwd}/.claude/as_you/session_archive/*.md` (where {pwd} is from step 1)
    - If no archives: "No archived notes found"
    - If archives exist:
      - For each file (sorted by date, newest first):
@@ -48,7 +49,7 @@ Display and manage session notes.
        - Label: "No, cancel"
          Description: "Keep current notes"
    - If confirmed:
-     - Execute: `> .claude/as_you/session_notes.local.md`
+     - Execute Bash: `> {pwd}/.claude/as_you/session_notes.local.md` (using absolute path)
      - Respond: "Session notes cleared"
    - If cancelled:
      - Respond: "Cancelled"

--- a/commands/promote.md
+++ b/commands/promote.md
@@ -12,8 +12,9 @@ Promote a frequent pattern to knowledge base (Skill or Agent).
 
 ### 1. Retrieve Promotion Candidates
 
-Execute:
+Get current directory and retrieve candidates:
 ```bash
+pwd
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/promotion_analyzer.py"
 ```
 
@@ -76,7 +77,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/pattern_context.py" PATTERN_NAME
 3. Launch component-generator agent:
    ```
    subagent_type: "as-you:component-generator"
-   prompt: "Create agent '{pattern-name}' with tools: {inferred-tools}. Context: {contexts}"
+   prompt: "Create agent '{pattern-name}' with tools: {inferred-tools}. Context: {contexts}. Working directory: {pwd} (use absolute paths for all file operations)"
    description: "Generate agent component"
    ```
 
@@ -86,7 +87,7 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/pattern_context.py" PATTERN_NAME
 2. Launch component-generator agent:
    ```
    subagent_type: "as-you:component-generator"
-   prompt: "Create skill '{pattern-name}'. Context: {contexts}"
+   prompt: "Create skill '{pattern-name}'. Context: {contexts}. Working directory: {pwd} (use absolute paths for all file operations)"
    description: "Generate skill component"
    ```
 
@@ -121,9 +122,9 @@ Present generated component and ask:
 
 ### 6. Check for Duplicates
 
-Before creating, search existing:
-- Skills: `skills/*/SKILL.md`
-- Agents: `agents/*.md`
+Before creating, search existing using Glob with absolute paths (where {pwd} is from step 1):
+- Skills: `{pwd}/skills/*/SKILL.md`
+- Agents: `{pwd}/agents/*.md`
 
 If similar name exists, warn and ask for confirmation.
 

--- a/commands/workflow-save.md
+++ b/commands/workflow-save.md
@@ -69,7 +69,9 @@ Use AskUserQuestion:
 
 ### 4. Generate Workflow Command
 
-Create `commands/{workflow-name}.md`:
+Get current directory with `pwd` using Bash tool.
+
+Create `{pwd}/commands/{workflow-name}.md` using Write tool with absolute path:
 
 ```markdown
 ---
@@ -119,7 +121,7 @@ Use AskUserQuestion:
     Description: "Don't save"
 
 **If "Yes":**
-- Write to `commands/{workflow-name}.md`
+- Write to `{pwd}/commands/{workflow-name}.md` using absolute path
 - Respond:
   ```
   Saved workflow: /as-you:{name}


### PR DESCRIPTION
## Summary

- Fixed workspace-relative file path issues in commands and agents
- Commands now use `pwd` to get current directory and construct absolute paths
- Ensures Read/Write tools work correctly with workspace-local .claude/as_you/ files

## Problem

Commands were using relative paths like `.claude/as_you/session_notes.local.md` for Read/Write operations, but these tools require absolute paths. Claude Code was misinterpreting `.claude` as the global `~/.claude` directory instead of workspace-local `.claude` directory:

```
Read(~/.claude/as_you/session_notes.local.md)
Error reading file
```

The actual file was at `/Users/.../current-workspace/.claude/as_you/session_notes.local.md`, but the command was looking in the user's home directory.

## Root Cause

1. Read/Write tools require absolute paths, not relative paths
2. Relative paths starting with `.claude` were misinterpreted as global config
3. As You uses **workspace-local storage** (`.claude/as_you/` in project root)

## Solution

Updated all commands and agents to:
1. Get current directory with `pwd` using Bash tool
2. Use absolute path format: `{pwd}/.claude/as_you/...`
3. Pass working directory to agents via prompt
4. Add file path guidelines to agent definitions

## Changed Files

### Commands
- **commands/notes.md**: Get pwd, use absolute paths for session notes/archives
- **commands/memory.md**: Get pwd, use absolute paths for stats, pass to memory-analyzer
- **commands/promote.md**: Get pwd, use absolute paths for duplicates check, pass to component-generator
- **commands/workflow-save.md**: Get pwd, use absolute paths for workflow creation

### Agents
- **agents/component-generator.md**: Add absolute path guidelines
- **agents/memory-analyzer.md**: Get pwd, use absolute paths for pattern_tracker.json
- **agents/pattern-curator.md**: Add absolute path guidelines for pattern database

## Design Philosophy Confirmation

This fix respects As You's **workspace-local storage** design:
- Each project maintains its own `.claude/as_you/` directory
- Pattern learning is project-specific
- Knowledge base (skills/agents) is project-scoped
- Session notes and archives are workspace-bound

## Test Plan

- [x] `/as-you:notes` now reads correct workspace file
- [x] `/as-you:memory` accesses workspace pattern_tracker.json
- [x] `/as-you:promote` searches workspace skills/agents
- [x] All file operations use correct absolute paths

Generated with [Claude Code](https://claude.com/claude-code)