### PR TITLE
Fix: Change workflow storage to .claude/commands with marker-based detection

### DIFF
--- a/commands/workflow-save.md
+++ b/commands/workflow-save.md
@@ -71,13 +71,15 @@ Use AskUserQuestion:
 
 Get current directory with `pwd` using Bash tool.
 
-Create `{pwd}/commands/{workflow-name}.md` using Write tool with absolute path:
+Create `{pwd}/.claude/commands/{workflow-name}.md` using Write tool with absolute path:
 
 ```markdown
 ---
 description: "{user-provided-description}"
 allowed-tools: [Bash, Read, Write, Edit, Grep, Glob]
 ---
+
+<!-- as-you:workflow -->
 
 # {Workflow Name}
 
@@ -121,7 +123,7 @@ Use AskUserQuestion:
     Description: "Don't save"
 
 **If "Yes":**
-- Write to `{pwd}/commands/{workflow-name}.md` using absolute path
+- Write to `{pwd}/.claude/commands/{workflow-name}.md` using absolute path
 - Respond:
   ```
   Saved workflow: /as-you:{name}

--- a/commands/workflows.md
+++ b/commands/workflows.md
@@ -11,12 +11,17 @@ View and manage saved workflows.
 
 ### 1. List Workflows
 
-Execute to find user workflows (exclude built-in commands):
+Get current directory and search for As You workflows:
 ```bash
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/workflow_list.py"
+pwd
 ```
 
-If no workflows:
+Use Grep to find workflows with As You marker:
+- Pattern: `as-you:workflow`
+- Path: `{pwd}/.claude/commands` (where {pwd} is from above)
+- Output mode: `files_with_matches`
+
+If no workflows found:
 - Respond: "No saved workflows found"
 - Guide: "Create workflows with /as-you:workflow-save"
 
@@ -54,7 +59,7 @@ Use AskUserQuestion:
 
 **If "View workflow details":**
 - Use AskUserQuestion to select workflow from list
-- Read `commands/{workflow-name}.md`
+- Read `{pwd}/.claude/commands/{workflow-name}.md` using absolute path
 - Display contents
 - Show metadata (file path, last modified)
 - Return to menu or exit
@@ -76,7 +81,7 @@ Use AskUserQuestion:
   - Generate updated workflow
   - Show preview (side-by-side or diff)
   - Confirm with AskUserQuestion
-  - If confirmed: Write to `commands/{name}.md`
+  - If confirmed: Write to `{pwd}/.claude/commands/{name}.md` using absolute path
   - Respond: "Workflow updated: {name}\n\nRestart session (/exit) to use updated workflow"
 
 **If "Delete workflow":**
@@ -90,7 +95,7 @@ Use AskUserQuestion:
     - Label: "No, cancel"
       Description: "Keep the workflow"
 - If confirmed:
-  - Execute: `rm commands/{name}.md`
+  - Execute Bash: `rm "{pwd}/.claude/commands/{name}.md"` using absolute path
   - Respond: "Workflow '{name}' deleted"
 - Return to menu or exit
 

--- a/scripts/commands/workflow_list.py
+++ b/scripts/commands/workflow_list.py
@@ -25,7 +25,7 @@ def list_workflows(commands_dir: Path | None = None) -> list[dict]:
     List user workflows sorted by modification time.
 
     Args:
-        commands_dir: Path to commands directory (default: ./commands)
+        commands_dir: Path to commands directory (default: .claude/commands)
 
     Returns:
         List of workflow dicts with 'name', 'mtime', and 'mtime_str' keys
@@ -61,7 +61,7 @@ def list_workflows(commands_dir: Path | None = None) -> list[dict]:
         >>> assert len(workflows) == 0
     """
     if commands_dir is None:
-        commands_dir = Path("commands")
+        commands_dir = Path(".claude/commands")
 
     if not commands_dir.exists():
         return []


### PR DESCRIPTION
## Summary

- Changed workflow storage from `commands/` to `.claude/commands/`
- Added `<!-- as-you:workflow -->` HTML comment marker for workflow identification
- Use Grep tool to detect As You-managed workflows
- Workflows now accessible as `/workflow-name` without plugin prefix

## Problem

Original design had workflow storage location issues:

1. **Storage location**: Workflows were saved to `commands/` (plugin directory or project root)
2. **Recognition**: Claude Code wouldn't recognize them as commands in wrong location
3. **Identification**: No way to distinguish As You workflows from other custom commands

## Solution

### New Storage Location: `.claude/commands/`

Workflows are now saved to `.claude/commands/` which is:
- **Recognized by Claude Code** as workspace-level custom commands
- **Accessible as `/workflow-name`** (no `/as-you:` prefix)
- **Shared with team** via version control (project-level scope)

### Marker-Based Detection

Each generated workflow includes:
```markdown
---
description: Workflow description
---

<!-- as-you:workflow -->

Workflow content...
```

The `/as-you:workflows` command uses Grep to find files with this marker:
```
Grep(pattern: "as-you:workflow", path: "{pwd}/.claude/commands")
```

### Benefits

1. **Clean separation**: As You workflows vs other custom commands
2. **No tracking files**: Marker embedded directly in workflow file
3. **Simple maintenance**: Single Grep query to list all workflows
4. **Proper integration**: Works with Claude Code's command system

## Changed Files

- **commands/workflow-save.md**: 
  - Save to `.claude/commands/` instead of `commands/`
  - Add `<!-- as-you:workflow -->` marker to generated files
  
- **commands/workflows.md**:
  - Use Grep with absolute path for workflow detection
  - Update all file paths to `.claude/commands/`
  
- **scripts/commands/workflow_list.py**:
  - Change default path from `commands` to `.claude/commands`

## Design Confirmation

This aligns with Claude Code's command discovery system:
- **Project commands** (`.claude/commands/`) - shown as "(project)"
- **Plugin commands** (plugin `commands/`) - shown as "(plugin:name)"  
- **Personal commands** (`~/.claude/commands/`) - shown as "(user)"

As You workflows are project-level custom commands, properly integrated into the Claude Code ecosystem.

## Test Plan

- [x] Workflows save to `.claude/commands/`
- [x] Marker included in generated files
- [x] Grep detection works correctly
- [x] `/as-you:workflows` lists only As You workflows
- [x] Workflows accessible as `/workflow-name`

Generated with [Claude Code](https://claude.com/claude-code)