### PR TITLE
Fix: Enforce English translation and prevent unsolicited suggestions in note command

### DIFF
--- a/commands/note.md
+++ b/commands/note.md
@@ -25,14 +25,21 @@ To view notes: /as-you:notes
 
 If $ARGUMENTS is provided:
 
-1. Translate $ARGUMENTS to English if needed:
-   - If already English, preserve as-is
-   - If another language, translate while preserving technical terms
+1. **CRITICAL: Translate to English**
+   - Detect input language
+   - If non-English: MUST translate to English (preserve technical terms, code, proper nouns)
+   - If already English: Use as-is
+   - Self-check: Verify output contains only English text
 
 2. Execute with Bash tool:
    ```bash
-   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/note_add.py" "<translated-text>"
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/commands/note_add.py" "<english-text>"
    ```
-   Replace `<translated-text>` with actual content from step 1.
+   Replace `<english-text>` with translated content from step 1.
 
-3. Respond: "Note added"
+3. **CRITICAL: Response protocol**
+   - Respond EXACTLY: "Note added"
+   - Do NOT add suggestions
+   - Do NOT ask questions
+   - Do NOT provide analysis
+   - Do NOT start conversations about the note content


### PR DESCRIPTION
## Summary

- Enforced English translation for all notes (MUST translate, not optional)
- Prevented unsolicited suggestions/questions after note saving
- Made /as-you:note strictly single-purpose: save and confirm only

## Problems

### Problem 1: Non-English notes saved without translation

**Observed behavior:**
```
User: /as-you:note "死んでるリポジトリと生きてるリポジトリの見分けがつかない"
Result: Japanese text saved directly to session_notes.local.md
```

**Root cause:**
```markdown
1. Translate $ARGUMENTS to English if needed:
   - If already English, preserve as-is
   - If another language, translate while preserving technical terms
```

The phrase "if needed" was ambiguous, allowing Claude to skip translation.

**Impact:**
- Pattern detection expects English-only notes (all notes translated before analysis)
- Non-English text breaks TF-IDF scoring and similarity detection
- Violates As You's core design: "All notes are translated to English before storage"

### Problem 2: Unsolicited suggestions after note saving

**Observed behavior:**
```
Claude: ノートを追加しました。このイシューについて、アクティブなリポジトリと
非アクティブなリポジトリを識別する分析を追加しましょうか？
```

**Root cause:**
```markdown
3. Respond: "Note added"
```

Claude interpreted this as a minimum response and added extra suggestions.

**Impact:**
- Violates single-purpose command design
- Creates unwanted conversation flow
- Users expect simple confirmation, not suggestions

## Solution

### Fix 1: Mandatory English translation

```markdown
1. **CRITICAL: Translate to English**
   - Detect input language
   - If non-English: MUST translate to English (preserve technical terms, code, proper nouns)
   - If already English: Use as-is
   - Self-check: Verify output contains only English text
```

Changes:
- "CRITICAL" label emphasizes importance
- "MUST translate" removes ambiguity
- "Self-check" step adds verification
- Clear preservation rules for technical content

### Fix 2: Strict response protocol

```markdown
3. **CRITICAL: Response protocol**
   - Respond EXACTLY: "Note added"
   - Do NOT add suggestions
   - Do NOT ask questions
   - Do NOT provide analysis
   - Do NOT start conversations about the note content
```

Changes:
- "CRITICAL" label emphasizes importance
- "EXACTLY" removes interpretation room
- Explicit prohibitions list what NOT to do

## Expected Behavior

```
User: /as-you:note "死んでるリポジトリと生きてるリポジトリの見分けがつかない"

Claude internal process:
1. Detect: Japanese input
2. Translate: "Cannot distinguish between active and inactive repositories"
3. Save: [14:48] Cannot distinguish between active and inactive repositories
4. Respond: "Note added"

User sees: "Note added"
(No suggestions, no questions, no analysis)
```

## Design Philosophy

The note command follows As You's core principles:
- **Local-First**: All processing local, no external calls
- **Explicit Over Implicit**: User explicitly records important information
- **Statistical Intelligence**: English-only enables TF-IDF, PMI, similarity detection
- **Simplicity First**: One command = one purpose

## Test Plan

- [x] Japanese input → English translation → saved correctly
- [x] English input → saved as-is
- [x] Response is exactly "Note added" (no extra text)
- [x] No suggestions/questions/analysis after saving

## Changed Files

- **commands/note.md**: Enforced translation, added response protocol

Generated with [Claude Code](https://claude.com/claude-code)