### PR TITLE
fix: remove hooks configuration from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,6 +7,5 @@
   },
   "homepage": "https://github.com/h315uk3/as_you",
   "repository": "https://github.com/h315uk3/as_you",
-  "license": "AGPL-3.0",
-  "hooks": "./hooks/hooks.json"
+  "license": "AGPL-3.0"
 }


### PR DESCRIPTION
## Summary

- Removed hooks configuration from plugin.json to resolve plugin initialization issue

## Changes

- Removed `"hooks": "./hooks/hooks.json"` line from `.claude-plugin/plugin.json`

## Context

**Note**: This issue may be specific to plugin development workspace where the plugin calls itself. The duplicate hooks error occurs because Claude Code automatically loads `hooks/hooks.json`, and explicitly specifying it in the manifest causes a conflict.

This change may need to be reverted for normal plugin usage scenarios. The `manifest.hooks` field should only be used to specify **additional** hook files beyond the standard `hooks/hooks.json`.

## Test plan

- [x] Verify plugin loads successfully
- [x] Confirm no errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)