### PR TITLE
feat: add with-me plugin and rename repository to symbiosis

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,47 @@
+# Code Style
+
+## Python Standards
+
+**Version**: Python 3.11+ required
+
+**Type Hints**: Required for all functions
+- Annotate parameters and return types
+- Use modern syntax: `list[str]`, `dict[str, Any]`
+
+**Doctests**: Required for all public functions
+- Include realistic examples
+- Cover edge cases and errors
+- Keep examples executable
+
+**Formatting**: Enforced by ruff
+- Line length: 88 characters
+- Double quotes for strings
+- Run `mise run lint` and `mise run format`
+
+## Shell Scripts
+
+**Use only for**:
+- Hook entry points
+- Environment setup
+- Calling Python modules
+
+**Keep under 10 lines** and delegate all logic to Python.
+
+## File Organization
+
+**Python modules**: `plugins/{plugin-name}/scripts/`
+- One module per logical component
+- Self-contained with doctest runner
+- 644 permissions (rw-r--r--)
+
+**Commands/Agents**: `plugins/{plugin-name}/commands/` or `agents/`
+- Frontmatter required with `description` and `allowed-tools`
+- Test interactively before commit
+
+## Documentation
+
+**Inline comments**: Only for complex algorithms or non-obvious behavior
+
+**Docstrings**: One-line summary + Examples section with doctests
+- Explain "why" not "what"
+- Include edge cases

--- a/.claude/rules/development-constraints.md
+++ b/.claude/rules/development-constraints.md
@@ -1,0 +1,44 @@
+# Development Constraints
+
+## Critical Rules
+
+### 1. No Speculation
+Never propose implementations based on assumptions. Always verify with official documentation, source code, or latest information via WebFetch/WebSearch.
+
+### 2. Root Cause Analysis Required
+Always identify and report the root cause before fixing errors. Never apply band-aid fixes without understanding the underlying issue.
+
+### 3. No Legacy Code Reuse
+Never copy-paste old implementation patterns. Verify API versions, check current best practices, and avoid deprecated patterns.
+
+## Technology Constraints
+
+**Allowed**:
+- Python 3.11+ standard library only
+- Built-in modules: pathlib, json, math, difflib, re, datetime
+
+**Forbidden**:
+- External Python packages
+- Network calls to external services
+- Database systems
+- Cloud APIs or authentication
+
+**Architecture**:
+- Local-first processing
+- File-based persistence (JSON, Markdown)
+- Human-readable formats
+- Testable, modular code
+
+## Quality Standards
+
+### Before Any Change
+1. Read the file first
+2. Verify approach with documentation
+3. Consider side effects
+4. Test locally
+
+### Error Handling
+- Handle errors at appropriate boundaries
+- Provide clear error messages
+- Log for debugging
+- Don't catch-all without reason

--- a/.claude/rules/documentation-principles.md
+++ b/.claude/rules/documentation-principles.md
@@ -1,0 +1,54 @@
+# Documentation Principles
+
+## Golden Rule: Avoid Volatile Information
+
+**Never document information that changes frequently.**
+
+### Volatile (DO NOT document)
+
+- Specific directory structures
+- File paths and file names
+- Version numbers
+- Concrete code examples
+- Tool commands and syntax
+- API signatures
+- Configuration details
+- Step-by-step procedures
+
+**Why**: These become outdated quickly, creating maintenance burden and misleading information.
+
+**Where to put**: Code comments, docstrings, or discover via code exploration.
+
+### Stable (DO document)
+
+- Why we make decisions (philosophy)
+- Design principles (constraints, values)
+- Architecture patterns (high-level)
+- Anti-patterns to avoid
+- Quality standards (what, not how)
+- Responsibilities (roles)
+
+**Why**: These rarely change and provide lasting value.
+
+## Documentation Hierarchy
+
+**CLAUDE.md**: Unchanging philosophy and core principles
+
+**CONTRIBUTING.md**: Stable process and contribution guidelines
+
+**.claude/rules/**: Agent-focused principles and constraints
+
+**Docstrings**: Function-specific documentation with examples
+
+**Code comments**: Implementation details and complex logic
+
+## Review Checklist
+
+Before adding documentation, ask:
+1. Will this be outdated in 6 months?
+2. Can this be discovered by reading code?
+3. Is this "what" (volatile) or "why" (stable)?
+
+**If volatile → Don't document it. Put in code or docstring.**
+
+**If stable → Document the principle, not the implementation.**

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,56 @@
+# Git Workflow
+
+## Branch Strategy
+
+**Format**: `{type}/{description}`
+
+**Types**: `feature/*`, `fix/*`, `docs/*`, `refactor/*`, `test/*`
+
+## Commit Guidelines
+
+**Format**:
+```
+type: brief description
+
+Optional detailed explanation.
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+**Types**: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `perf:`
+
+**Best Practices**:
+- Write clear, descriptive messages
+- Keep commits atomic (one logical change)
+- Use present tense ("add" not "added")
+- Run tests before committing
+- Never commit broken code or secrets
+
+## Pull Request
+
+**Before PR**:
+1. `mise run test`
+2. `mise run lint`
+3. `mise run validate`
+
+**Requirements**:
+- Clear title and description
+- All tests passing
+- No lint errors
+- Updated documentation (if applicable)
+
+**Merge strategy**: Squash and merge (preferred) for clean history
+
+## Safety Rules
+
+**NEVER**:
+- Force push to main/master
+- Commit to main directly
+- Rebase shared branches
+- Commit secrets or API keys
+
+**ALWAYS**:
+- Review changes before committing (`git diff`)
+- Test before pushing
+- Keep commits focused
+- Update documentation with code

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,56 @@
+# Testing
+
+## Philosophy
+
+Every function must be testable:
+- Clear input/output contracts
+- Reproducible with mock data
+- No external dependencies
+
+## Doctest-Driven Development
+
+**Why**: Tests are documentation, stay synchronized, and are executable specifications.
+
+**Coverage Requirements**:
+- Normal operation (happy path)
+- Edge cases (empty input, max values)
+- Boundary conditions (0, 1, n-1, n)
+- Error conditions (invalid input, missing files)
+
+**Use realistic data**, not trivial tests like `1 + 1 == 2`.
+
+## Running Tests
+
+```bash
+mise run test           # All doctests
+mise run test:verbose   # Verbose output
+mise run test:watch     # Auto-run on changes
+```
+
+## Interactive Testing
+
+**Manual testing required for**:
+- Slash commands (UI interaction)
+- AskUserQuestion flows
+- Agent behavior
+- Hook triggers
+
+**Procedure**:
+1. Start fresh session: `/exit` then `claude-code`
+2. Test command with various inputs
+3. Verify output and file changes
+4. Test edge cases (invalid input, cancellation)
+
+## CI/CD
+
+All checks must pass before merging:
+1. `mise run lint`
+2. `mise run test`
+3. `mise run validate`
+
+## Test-First Workflow
+
+1. Write doctest (it fails)
+2. Implement function
+3. Verify (it passes)
+4. Commit with confidence

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,12 @@ Thank you for your interest in contributing to Symbiosis plugins!
 - **Purpose**: CONTRIBUTING.md stays stable; volatile details live in code/docstrings
 - **Responsibility**: Contributors update docstrings, not CONTRIBUTING; maintainers enforce separation
 
+**Volatile Information Forbidden:**
+- **Why**: Directory structures, file paths, version numbers, code examples, and tool commands become outdated quickly
+- **Purpose**: Prevent documentation rot and maintenance burden
+- **Responsibility**: Contributors must document "why" (principles) not "what" (implementation); reviewers reject PRs with volatile information in docs
+- **Rule**: Never document directory structures, file paths, version numbers, concrete code examples, tool syntax, API signatures, configuration details, or step-by-step procedures in CONTRIBUTING.md or .claude/rules/
+
 ### Roles and Responsibilities
 
 **Contributors:**


### PR DESCRIPTION
## Summary

This PR introduces three major changes to evolve the plugin ecosystem:

1. **Add with-me plugin**: Collaborative requirement elicitation with entropy-based questioning
2. **Rename repository**: as_you → symbiosis (version 0.2.0)
3. **Add development rules**: Agent-focused guidelines in `.claude/rules/`

## Changes

### 1. With-Me Plugin

**New plugin for collaborative development**:
- `/with-me:good-question` - Information-theoretic requirement elicitation with automatic effectiveness tracking
- `/with-me:stats` - Question effectiveness dashboard with reward-based analytics
- Adaptive questioning based on uncertainty dimensions
- Structured specification generation via forked context analysis

### 2. Repository Rename

**Rename to symbiosis (v0.2.0)**:
- Updated repository URLs from `as_you` to `symbiosis` across all files
- Bumped plugin versions from 0.1.0 to 0.2.0
- Updated marketplace metadata version to 0.2.0
- Removed rust toolchain dependency from mise.toml
- Updated installation instructions with new repository name

**Philosophy**: Represents the symbiotic relationship between human developers and AI

### 3. Development Rules

**Added `.claude/rules/` (6.5KB, ~2000 tokens)**:
- `development-constraints.md`: Critical rules and technology constraints
- `code-style.md`: Python standards, type hints, and doctest requirements
- `testing.md`: Test philosophy and doctest-driven development
- `git-workflow.md`: Branch strategy and commit guidelines
- `documentation-principles.md`: Volatile information prohibition

**Policy**: Added "Volatile Information Forbidden" to CONTRIBUTING.md

**Removed**: `.claude/CLAUDE.md` (redundant with CLAUDE.md and CONTRIBUTING.md)

## Test Plan

- [x] with-me commands tested interactively
- [x] Repository URLs updated correctly
- [x] Plugin versions bumped to 0.2.0
- [x] mise tasks (test, lint, validate) pass
- [x] Documentation updated

## Breaking Changes

None - this is a repository rename with new features added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)