### PR TITLE
chore: bump with-me version to 0.2.1

### DIFF
--- a/plugins/with-me/.claude-plugin/plugin.json
+++ b/plugins/with-me/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "with-me",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Collaborative development and team workflow assistant for Claude Code - You work with me (Claude)",
   "author": {
     "name": "h315uk3"


### PR DESCRIPTION
## Summary
Version bump from 0.2.0 to 0.2.1 following bug fix in #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)