### PR TITLE
fix(with-me): clarify dimension data flow between good-question and requirement-analysis

### DIFF
--- a/plugins/with-me/skills/requirement-analysis/SKILL.md
+++ b/plugins/with-me/skills/requirement-analysis/SKILL.md
@@ -55,7 +55,52 @@ Provide:
 
 ## Input Format
 
-Provide the raw interview data in any format:
+**PREFERRED: Dimension Data JSON (from /good-question)**
+
+If invoked after a `/good-question` interview, provide dimension data in JSON format:
+
+```json
+{
+  "purpose": {
+    "answered": true,
+    "content": "English summary of purpose answers with examples",
+    "examples": 2,
+    "contradictions": false
+  },
+  "data": {
+    "answered": true,
+    "content": "English summary of data answers with examples",
+    "examples": 1,
+    "contradictions": false
+  },
+  "behavior": {
+    "answered": true,
+    "content": "English summary of behavior answers with examples",
+    "examples": 3,
+    "contradictions": false
+  },
+  "constraints": {
+    "answered": true,
+    "content": "English summary of constraints answers with examples",
+    "examples": 1,
+    "contradictions": false
+  },
+  "quality": {
+    "answered": true,
+    "content": "English summary of quality answers with examples",
+    "examples": 0,
+    "contradictions": false
+  }
+}
+```
+
+**CRITICAL**: Content fields MUST be in English for uncertainty calculation to work correctly.
+
+---
+
+**ALTERNATIVE: Raw Interview Data**
+
+For ad-hoc analysis without `/good-question`, provide raw interview data:
 
 ```markdown
 ## Interview Transcript


### PR DESCRIPTION
## Summary

Fixes the bug where Claude incorrectly attempts to read non-existent session files when invoking the requirement-analysis skill from good-question command.

## Root Cause

- **Session data path mismatch**: Actual storage location is `<project_root>/.claude/with_me/question_feedback.json`, but Claude was inferring `${CLAUDE_PLUGIN_ROOT}/data/sessions/<session_id>.json`
- **Incomplete Phase 5 instructions**: good-question.md did not explicitly document how to prepare and pass dimension data to requirement-analysis skill

## Changes Made

### 1. good-question.md (Phase 5)
- Added **Step 1**: Explicit dimension data JSON compilation with examples
- Added **Step 2**: Uncertainty verification before skill invocation
- Added **Step 3**: Correct way to pass data to requirement-analysis skill
- Documented critical requirement: content must be in English for word count analysis

### 2. requirement-analysis SKILL.md (Input Format)
- Added **PREFERRED format**: Dimension data JSON from /good-question
- Added **ALTERNATIVE format**: Raw interview data (legacy method)
- Clarified that skill receives data through prompt, NOT from session files

## Verification

- ✅ Session file is correctly saved to `<project_root>/.claude/with_me/question_feedback.json`
- ✅ Uncertainty calculator works correctly with dimension data JSON
- ✅ Path is dynamically determined (no hardcoded paths)

## Test Plan

1. Run `/good-question` interview to completion
2. Follow Phase 5 instructions to prepare dimension data JSON
3. Verify uncertainty calculator processes the data correctly
4. Invoke requirement-analysis skill with prepared data
5. Confirm skill receives data correctly and generates specification

🤖 Generated with [Claude Code](https://claude.com/claude-code)