### PR TITLE
fix(with-me): wait for detailed explanation after AskUserQuestion selection

### DIFF
--- a/plugins/with-me/.claude-plugin/plugin.json
+++ b/plugins/with-me/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "with-me",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Collaborative development and team workflow assistant for Claude Code - You work with me (Claude)",
   "author": {
     "name": "h315uk3"

--- a/plugins/with-me/commands/good-question.md
+++ b/plugins/with-me/commands/good-question.md
@@ -482,10 +482,14 @@ export PYTHONPATH="${CLAUDE_PLUGIN_ROOT}" && python3 -m with_me.commands.session
   - Label: "User needs", Description: "There's a specific user need or pain point"
   - Label: "Technical requirement", Description: "This is needed for technical reasons"
 
-Follow up with:
+**CRITICAL: After receiving the user's selection, ask follow-up questions to get detailed explanation:**
+
+Based on their selection, ask appropriate follow-up questions:
 - "Who experiences this problem?"
 - "What happens if this isn't built?"
 - "What does success look like from the user's perspective?"
+
+**Wait for the user's detailed explanation before proceeding to record and move to the next dimension.**
 
 #### If Data has highest uncertainty:
 
@@ -498,10 +502,14 @@ Follow up with:
   - Label: "Show examples", Description: "I have sample data or schemas"
   - Label: "Not sure yet", Description: "I haven't thought about the data structure"
 
-Follow up with:
+**CRITICAL: After receiving the user's selection, ask follow-up questions to get detailed explanation:**
+
+Based on their selection, ask appropriate follow-up questions:
 - "What triggers data to enter the system?"
 - "What format is the data in?"
 - "What information must be preserved vs transformed?"
+
+**Wait for the user's detailed explanation before proceeding to record and move to the next dimension.**
 
 #### If Behavior has highest uncertainty:
 
@@ -514,10 +522,14 @@ Follow up with:
   - Label: "Similar to existing", Description: "It works like [reference] but with differences"
   - Label: "Uncertain", Description: "I'm not sure about the exact flow"
 
-Follow up with:
+**CRITICAL: After receiving the user's selection, ask follow-up questions to get detailed explanation:**
+
+Based on their selection, ask appropriate follow-up questions:
 - "What initiates this process?"
 - "What are the critical decision points?"
 - "When does the process complete?"
+
+**Wait for the user's detailed explanation before proceeding to record and move to the next dimension.**
 
 #### If Constraints have highest uncertainty:
 
@@ -531,10 +543,14 @@ Follow up with:
   - Label: "Compatibility needs", Description: "Must work with specific versions or systems"
   - Label: "No specific constraints", Description: "Standard practices are fine"
 
+**CRITICAL: After receiving the user's selection(s), ask follow-up questions for each selected constraint:**
+
 For each selected constraint, drill deeper:
 - Performance: "What are the acceptable thresholds?"
 - Security: "What are the threat scenarios?"
 - Compatibility: "What must be supported?"
+
+**Wait for the user's detailed explanation before proceeding to record and move to the next dimension.**
 
 #### If Quality has highest uncertainty:
 
@@ -547,10 +563,14 @@ For each selected constraint, drill deeper:
   - Label: "Follow standards", Description: "Apply standard testing practices"
   - Label: "Not sure", Description: "I need help defining success criteria"
 
-Follow up with:
+**CRITICAL: After receiving the user's selection, ask follow-up questions to get detailed explanation:**
+
+Based on their selection, ask appropriate follow-up questions:
 - "What are the critical success scenarios?"
 - "What edge cases concern you?"
 - "What failure modes should be handled?"
+
+**Wait for the user's detailed explanation before proceeding to record and move to the next dimension.**
 
 ---
 


### PR DESCRIPTION
## Summary

Fixed a critical bug where the good-question command would skip to the next dimension immediately after a user selected an option from AskUserQuestion, without waiting for their detailed explanation. Now Claude properly waits for follow-up details before proceeding.

## Problem

When using `/with-me:good-question`, after answering an initial selection question (e.g., selecting "Walk through it" for the Behavior dimension), Claude would immediately move to the next dimension question (e.g., Constraints) without asking for or waiting for the detailed explanation the user wanted to provide.

### Example of the Bug

1. Claude asks: "What should happen step by step?"
2. User selects: "Walk through it" (indicating they want to explain the flow)
3. **BUG**: Claude immediately jumps to next question: "Any constraints I should know about?"
4. User's detailed flow explanation is never collected

### Root Cause

The "Follow up with:" sections in `good-question.md` were formatted as optional examples, not explicit instructions. Claude interpreted these as informational guidance rather than mandatory steps to execute. There was no clear instruction to:
1. Ask the follow-up questions
2. Wait for the user's detailed response
3. Only then proceed to recording and the next dimension

### Impact

- Incomplete requirement gathering
- User frustration (wanted to explain but wasn't given the opportunity)
- Poor interview quality (missing critical details)
- Wasted user time (had to restart or clarify later)

## Solution

Added explicit "CRITICAL:" instructions after each AskUserQuestion in Phase 2-2 (deep-dive questioning) to ensure Claude:
1. Recognizes follow-up questions are mandatory, not optional
2. Asks appropriate follow-up questions based on user's selection
3. Waits for detailed explanation before proceeding
4. Records complete information before moving to next dimension

### Changes

Modified `plugins/with-me/commands/good-question.md`:

**For all 5 dimensions (Purpose, Data, Behavior, Constraints, Quality):**

- Changed "Follow up with:" to "**CRITICAL: After receiving the user's selection, ask follow-up questions to get detailed explanation:**"
- Made follow-up questions explicit requirements, not examples
- Added: "**Wait for the user's detailed explanation before proceeding to record and move to the next dimension.**"

**Updated `plugins/with-me/.claude-plugin/plugin.json`:**
- Bumped version from 0.2.6 to 0.2.7

## Test Plan

- [x] Manual verification: Run `/with-me:good-question` command
- [x] Select "Walk through it" for Behavior question
- [x] Verify Claude asks follow-up questions
- [x] Verify Claude waits for detailed explanation
- [x] Confirm proper recording before proceeding to next dimension

## Verification Steps

1. Start `/with-me:good-question` session
2. When asked "What should happen step by step?", select "Walk through it"
3. **Expected**: Claude asks follow-up questions like "What initiates this process?"
4. Provide detailed explanation
5. **Expected**: Claude records the explanation before moving to Constraints dimension
6. Verify no dimensions are skipped

## Related Issues

This bug was discovered during actual usage when a user selected "フローを説明" (Walk through it in Japanese) and Claude immediately moved to the next question without collecting the flow explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)