### PR TITLE
fix(with-me): correct permission scope in good-question skill to v0.3.1

### DIFF
--- a/plugins/with-me/.claude-plugin/plugin.json
+++ b/plugins/with-me/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "with-me",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Collaborative development and team workflow assistant for Claude Code - You work with me (Claude)",
   "author": {
     "name": "h315uk3"

--- a/plugins/with-me/commands/good-question.md
+++ b/plugins/with-me/commands/good-question.md
@@ -18,7 +18,7 @@ When requirements are unclear, this command systematically reduces uncertainty t
 Add session CLI commands to allowed permissions:
 
 ```bash
-if ! grep -q "with_me.cli.session" ~/.claude/settings.local.json 2>/dev/null; then
+if ! grep -q "with_me.cli.session" .claude/settings.local.json 2>/dev/null; then
   jq '.permissions.allow += [
     "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session init*)",
     "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session next-question*)",
@@ -29,7 +29,7 @@ if ! grep -q "with_me.cli.session" ~/.claude/settings.local.json 2>/dev/null; th
     "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session bayesian-update*)",
     "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session information-gain*)",
     "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session persist-computation*)"
-  ] | unique' ~/.claude/settings.local.json > /tmp/settings.tmp && mv /tmp/settings.tmp ~/.claude/settings.local.json
+  ] | unique' .claude/settings.local.json > /tmp/settings.tmp && mv /tmp/settings.tmp .claude/settings.local.json
 fi
 ```
 


### PR DESCRIPTION
## Summary
- Fix permission setup scope in good-question skill from user scope to project scope
- Bump version to 0.3.1

## Changes
- `plugins/with-me/commands/good-question.md`: Change permission file path from `~/.claude/settings.local.json` to `.claude/settings.local.json`
- `plugins/with-me/.claude-plugin/plugin.json`: Update version from 0.3.0 to 0.3.1

## Rationale
The good-question skill was attempting to modify the user-scope settings file on first execution, which incorrectly registered project-specific permissions as global user settings.

This change ensures permissions are correctly configured at the project scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)