### PR TITLE
fix(with-me): use CLAUDE_PLUGIN_ROOT for plugin path resolution

### DIFF
--- a/plugins/with-me/commands/good-question.md
+++ b/plugins/with-me/commands/good-question.md
@@ -40,7 +40,7 @@ This adds permissions for all session commands required by the adaptive question
 Execute the session CLI to initialize:
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session init
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session init
 ```
 
 Expected output:
@@ -59,7 +59,7 @@ Repeat until convergence:
 Get next dimension to query:
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session next-question --session-id <SESSION_ID>
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session next-question --session-id <SESSION_ID>
 ```
 
 If output shows `"converged": true`, skip to step 3. Otherwise, note the `dimension` and `dimension_name`.
@@ -67,7 +67,7 @@ If output shows `"converged": true`, skip to step 3. Otherwise, note the `dimens
 Get current session state:
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session status --session-id <SESSION_ID>
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session status --session-id <SESSION_ID>
 ```
 
 Read dimension configuration from `config/dimensions.json` for the selected dimension.
@@ -102,7 +102,7 @@ MUST invoke `/with-me:question-importance` skill:
 
 First, get current beliefs from session status:
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session status --session-id <SESSION_ID>
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session status --session-id <SESSION_ID>
 ```
 
 Extract the posterior distribution for the selected dimension from the status output.
@@ -159,7 +159,7 @@ Handle user response:
 MUST execute this CLI command using Bash tool:
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session update \
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session update \
   --session-id <SESSION_ID> \
   --dimension <DIMENSION> \
   --question <QUESTION> \
@@ -180,7 +180,7 @@ The likelihoods should sum to approximately 1.0.
 MUST execute this CLI command using Bash tool:
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session compute-entropy \
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session compute-entropy \
   --session-id <SESSION_ID> \
   --dimension <DIMENSION>
 ```
@@ -199,7 +199,7 @@ Then, MUST invoke `/with-me:entropy` skill with:
 MUST execute this CLI command using Bash tool:
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session bayesian-update \
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session bayesian-update \
   --session-id <SESSION_ID> \
   --dimension <DIMENSION> \
   --likelihoods "$LIKELIHOODS"
@@ -233,7 +233,7 @@ MUST invoke `/with-me:information-gain` skill with:
 MUST execute this CLI command using Bash tool:
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session persist-computation \
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session persist-computation \
   --session-id <SESSION_ID> \
   --dimension <DIMENSION> \
   --question <QUESTION> \
@@ -251,7 +251,7 @@ The CLI will confirm persistence and increment the question count.
 Show entropy reduction to user:
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session status --session-id <SESSION_ID>
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session status --session-id <SESSION_ID>
 ```
 
 Output:
@@ -281,7 +281,7 @@ Return to step 2.1-2.2.
 ### 3. Complete Session
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.cli.session complete --session-id <SESSION_ID>
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.cli.session complete --session-id <SESSION_ID>
 ```
 
 Output:

--- a/plugins/with-me/commands/stats.md
+++ b/plugins/with-me/commands/stats.md
@@ -22,7 +22,7 @@ Shows:
 ### 1. Collect Raw Data
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.lib.question_stats --enhanced
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.lib.question_stats --enhanced
 ```
 
 This outputs raw session data in JSON format. Store the output for skill processing.
@@ -66,7 +66,7 @@ When you need to optimize session configuration parameters (convergence_threshol
 **a) Collect parameter tuning data:**
 
 ```bash
-PYTHONPATH="plugins/with-me:${PYTHONPATH:-}" python3 -m with_me.lib.parameter_tuner --collect
+PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m with_me.lib.parameter_tuner --collect
 ```
 
 This outputs:


### PR DESCRIPTION
## Summary
- Replace hardcoded plugin path with `${CLAUDE_PLUGIN_ROOT}` environment variable
- Fixes module import errors when plugin is installed
- Bump version to 0.3.1

## Changes
- `plugins/with-me/commands/good-question.md`: Replace `PYTHONPATH="plugins/with-me:..."` with `PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:..."`
- `plugins/with-me/commands/stats.md`: Same path resolution fix
- `plugins/with-me/.claude-plugin/plugin.json`: Update version to 0.3.1

## Problem
The plugin was using hardcoded relative path `plugins/with-me` which only works in development mode. When installed, the plugin is cached to `~/.claude/plugins/cache/symbiosis/with-me/<version>/`, causing Python module imports to fail with `ModuleNotFoundError`.

## Solution
Use `${CLAUDE_PLUGIN_ROOT}` environment variable provided by Claude Code plugin system. This variable points to the correct plugin directory in both:
- Development mode: Project's `plugins/with-me/` directory
- Installed mode: `~/.claude/plugins/cache/symbiosis/with-me/<version>/` directory

## Testing
Verified that `${CLAUDE_PLUGIN_ROOT}` is available during skill execution and correctly resolves to the plugin installation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)