### PR TITLE
fix(with-me): use CLAUDE_PLUGIN_ROOT for plugin path resolution

### DIFF
--- a/plugins/with-me/commands/good-question.md
+++ b/plugins/with-me/commands/good-question.md
@@ -20,15 +20,15 @@ Add session CLI commands to allowed permissions:
 ```bash
 if ! grep -q "with_me.cli.session" .claude/settings.local.json 2>/dev/null; then
   jq '.permissions.allow += [
-    "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session init*)",
-    "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session next-question*)",
-    "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session update*)",
-    "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session status*)",
-    "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session complete*)",
-    "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session compute-entropy*)",
-    "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session bayesian-update*)",
-    "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session information-gain*)",
-    "Bash(PYTHONPATH=\"plugins/with-me:${PYTHONPATH:-}\" python3 -m with_me.cli.session persist-computation*)"
+    "Bash(PYTHONPATH=\"${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}\" python3 -m with_me.cli.session init*)",
+    "Bash(PYTHONPATH=\"${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}\" python3 -m with_me.cli.session next-question*)",
+    "Bash(PYTHONPATH=\"${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}\" python3 -m with_me.cli.session update*)",
+    "Bash(PYTHONPATH=\"${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}\" python3 -m with_me.cli.session status*)",
+    "Bash(PYTHONPATH=\"${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}\" python3 -m with_me.cli.session complete*)",
+    "Bash(PYTHONPATH=\"${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}\" python3 -m with_me.cli.session compute-entropy*)",
+    "Bash(PYTHONPATH=\"${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}\" python3 -m with_me.cli.session bayesian-update*)",
+    "Bash(PYTHONPATH=\"${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}\" python3 -m with_me.cli.session information-gain*)",
+    "Bash(PYTHONPATH=\"${CLAUDE_PLUGIN_ROOT}:${PYTHONPATH:-}\" python3 -m with_me.cli.session persist-computation*)"
   ] | unique' .claude/settings.local.json > /tmp/settings.tmp && mv /tmp/settings.tmp .claude/settings.local.json
 fi
 ```


### PR DESCRIPTION
## Summary
- Replace hardcoded plugin path with `${CLAUDE_PLUGIN_ROOT}` environment variable in both execution commands and permission patterns
- Fixes module import errors when plugin is installed

## Changes
- `plugins/with-me/commands/good-question.md`: 
  - Replace all `PYTHONPATH="plugins/with-me:..."` with `PYTHONPATH="${CLAUDE_PLUGIN_ROOT}:..."`
  - Update permission patterns to match execution commands
- `plugins/with-me/commands/stats.md`: Same path resolution fix

## Problem
The plugin was using hardcoded relative path `plugins/with-me` which only works in development mode. When installed, the plugin is cached to `~/.claude/plugins/cache/symbiosis/with-me/<version>/`, causing Python module imports to fail with `ModuleNotFoundError`.

Additionally, permission patterns were inconsistent with actual execution commands, potentially blocking legitimate operations.

## Solution
Use `${CLAUDE_PLUGIN_ROOT}` environment variable provided by Claude Code plugin system. This variable points to the correct plugin directory in both:
- Development mode: Project's `plugins/with-me/` directory
- Installed mode: `~/.claude/plugins/cache/symbiosis/with-me/<version>/` directory

## Testing
Ensures compatibility with both development and installed plugin modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)