### PR TITLE
fix(as-you): bump version to 0.3.0 in plugin.json

### DIFF
--- a/plugins/as-you/.claude-plugin/plugin.json
+++ b/plugins/as-you/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "as-you",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Local pattern learning and external memory plugin for Claude Code with positive/negative learning, meta-development tools, and custom workflows",
   "author": {
     "name": "h315uk3"


### PR DESCRIPTION
## Summary
- Bumps as-you plugin version from 0.2.2 to 0.3.0 in plugin.json
- Version file was missed during #82 architecture refactor merge

## Test plan
- [x] Verify plugin.json contains correct version 0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)