### PR TITLE
fix: resolve LaTeX underscore rendering errors in GitHub Markdown

### DIFF
--- a/plugins/as-you/docs/technical-overview.md
+++ b/plugins/as-you/docs/technical-overview.md
@@ -137,9 +137,9 @@ $$\text{BM25}(d, q) = \sum_{t \in q} \text{IDF}(t) \cdot \frac{f(t, d) \cdot (k_
 
 Prioritizes recent patterns with exponential decay:
 
-$$\text{score}(t) = \text{base\_score} \cdot e^{-\lambda \cdot \Delta t}$$
+$$\text{score}(t) = \text{base score} \cdot e^{-\lambda \cdot \Delta t}$$
 
-where $\lambda = \frac{\ln 2}{\text{half\_life}}$ and half-life defaults to 30 days.
+where $\lambda = \frac{\ln 2}{\text{half life}}$ and half-life defaults to 30 days.
 
 #### Bayesian Confidence
 

--- a/plugins/with-me/docs/technical-overview.md
+++ b/plugins/with-me/docs/technical-overview.md
@@ -176,8 +176,8 @@ The system uses several configurable thresholds in `config/dimensions.json`:
 
 ### Question Limits
 
-- **max_questions** (default: 50): Safety limit to prevent infinite loops
-- **min_questions** (default: 5): Minimum questions before allowing early termination
+- `max_questions` (default: 50): Safety limit to prevent infinite loops
+- `min_questions` (default: 5): Minimum questions before allowing early termination
 
 ### Likelihood Validation
 


### PR DESCRIPTION
## Summary
- Fixed "_ allowed only in math mode" errors in technical documentation
- Ensured proper LaTeX rendering on GitHub Markdown

## Changes
- **plugins/as-you/docs/technical-overview.md**: Removed escaped underscores in `\text{}` environments
  - `\text{base\_score}` → `\text{base score}`
  - `\text{half\_life}` → `\text{half life}`
- **plugins/with-me/docs/technical-overview.md**: Changed bold variable names to inline code formatting
  - `**max_questions**` → `` `max_questions` ``
  - `**min_questions**` → `` `min_questions` ``

## Root Cause
GitHub's Markdown+LaTeX renderer does not require escaping underscores within `\text{}` environments. Escaped underscores (`\_`) in `\text{}` and underscores in bold formatting can be misinterpreted during LaTeX conversion, causing rendering errors.

## Test Plan
- [x] All doctests pass
- [x] Linter passes
- [x] Pre-commit hooks pass
- [x] Verified LaTeX syntax correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)