### PR TITLE
chore: bump as-you to 0.3.3 and remove volatile version info

### DIFF
--- a/plugins/as-you/.claude-plugin/plugin.json
+++ b/plugins/as-you/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "as-you",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Local pattern learning and external memory plugin for Claude Code with positive/negative learning, meta-development tools, and custom workflows",
   "author": {
     "name": "h315uk3"

--- a/plugins/as-you/as_you/hooks/pattern_merger.py
+++ b/plugins/as-you/as_you/hooks/pattern_merger.py
@@ -228,7 +228,7 @@ def merge_similar_patterns_batch(
                 {"keep": keep, "merge": merge, "distance": distance, "error": str(e)}
             )
 
-    # Recalculate all scores using v0.3.0 orchestrator
+    # Recalculate all scores using orchestrator
     try:
         archive_dir = tracker_file.parent / "session_archive"
         if archive_dir.exists():

--- a/plugins/as-you/as_you/hooks/score_calculator_hook.py
+++ b/plugins/as-you/as_you/hooks/score_calculator_hook.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Score calculator hook for As You plugin (v0.3.0).
+Score calculator hook for As You plugin.
 Uses AnalysisOrchestrator with BM25, time decay, and composite scoring.
 """
 
@@ -17,7 +17,7 @@ from as_you.lib.common import AsYouConfig
 
 
 def main():
-    """CLI entry point for score calculation (v0.3.0)."""
+    """CLI entry point for score calculation."""
     # Get paths from environment using common config
     config = AsYouConfig.from_environment()
 
@@ -29,7 +29,7 @@ def main():
         result = orchestrator.run_analysis(skip_merge=True)
 
         print(
-            f"v0.3.0 Scoring complete: {result.patterns_analyzed} patterns analyzed, "
+            f"Scoring complete: {result.patterns_analyzed} patterns analyzed, "
             f"{result.scores_updated} scores updated "
             f"({result.duration_ms:.1f}ms)"
         )

--- a/plugins/as-you/as_you/lib/analysis_orchestrator.py
+++ b/plugins/as-you/as_you/lib/analysis_orchestrator.py
@@ -342,7 +342,7 @@ class AnalysisOrchestrator:
                 }
                 scores_updated += 1
 
-        # 6. SM-2 state initialization (quality updates deferred to v0.3.1)
+        # 6. SM-2 state initialization
         memory_config = config.settings.get("memory", {})
         sm2_config = memory_config.get("sm2", {})
         if sm2_config.get("enabled", True):

--- a/plugins/as-you/commands/help.md
+++ b/plugins/as-you/commands/help.md
@@ -1,9 +1,9 @@
 ---
-description: "As You v0.3.2: pattern learning and external memory"
+description: "As You: pattern learning and external memory"
 allowed-tools: []
 ---
 
-# As You v0.3.2
+# As You
 
 Pattern learning plugin. Captures observations, detects patterns, applies learned habits.
 

--- a/plugins/as-you/docs/technical-overview.md
+++ b/plugins/as-you/docs/technical-overview.md
@@ -291,20 +291,7 @@ $$\theta_i \sim \text{Beta}(\alpha_i, \beta_i)$$
 
 **Location:** `.claude/as_you/`
 
-**Structure:**
-```
-.claude/as_you/
-├── session_notes.local.md          # Current session (not committed)
-├── session_archive/
-│   ├── 2026-01-20.md
-│   ├── 2026-01-21.md
-│   └── 2026-01-22.md
-├── pattern_tracker.json            # Pattern database with scores
-├── workflows/
-│   ├── api-endpoint-setup.md
-│   └── react-component-testing.md
-└── skill-usage-stats.json          # Knowledge base metrics
-```
+See `/as-you:help` for file descriptions. Explore the directory for actual structure.
 
 **Pattern Tracker Schema:**
 ```json

--- a/plugins/as-you/tests/e2e/commands/help.md
+++ b/plugins/as-you/tests/e2e/commands/help.md
@@ -17,7 +17,7 @@ Test the help command: display plugin documentation and command reference.
 
 **Expected behavior:**
 - [ ] Displays plugin information:
-  - Plugin name and version (e.g., "As You v0.3.2")
+  - Plugin name
   - Brief description
 - [ ] Lists all available commands with usage:
   - `/as-you:learn [note]`
@@ -150,9 +150,7 @@ Help should be formatted with:
 - [ ] Proper spacing and readability
 
 ### Step 2: Check Accuracy
-- [ ] Version number matches plugin.json
 - [ ] Command syntax matches actual implementation
-- [ ] File paths are correct
 - [ ] No outdated information
 
 ---

--- a/plugins/with-me/with_me/lib/question_feedback_manager.py
+++ b/plugins/with-me/with_me/lib/question_feedback_manager.py
@@ -66,7 +66,7 @@ class QuestionData(TypedDict, total=False):
     """
     Type definition for a single question
 
-    v0.3.0 Extensions:
+    Extensions:
     - dimension_beliefs_before: Posterior distributions before question
     - dimension_beliefs_after: Posterior distributions after answer
     """
@@ -77,7 +77,7 @@ class QuestionData(TypedDict, total=False):
     context: dict[str, Any]
     answer: dict[str, Any]
     reward_scores: dict[str, float]
-    # v0.3.0: Bayesian belief tracking
+    # Bayesian belief tracking
     dimension_beliefs_before: dict[str, dict] | None  # Serialized HypothesisSet
     dimension_beliefs_after: dict[str, dict] | None  # Serialized HypothesisSet
 
@@ -97,7 +97,7 @@ class SessionData(TypedDict, total=False):
     """
     Type definition for a session
 
-    v0.3.0 Extensions:
+    Extensions:
     - initial_dimension_beliefs: Starting posterior distributions
     - final_dimension_beliefs: Ending posterior distributions
     """
@@ -108,7 +108,7 @@ class SessionData(TypedDict, total=False):
     duration_seconds: int | None
     questions: list[QuestionData]
     summary: SessionSummary | None
-    # v0.3.0: Bayesian belief tracking
+    # Bayesian belief tracking
     initial_dimension_beliefs: dict[str, dict] | None  # Serialized HypothesisSet
     final_dimension_beliefs: dict[str, dict] | None  # Serialized HypothesisSet
 
@@ -238,7 +238,7 @@ class QuestionFeedbackManager:
         Start a new session
 
         Args:
-            initial_dimension_beliefs: Optional initial Bayesian beliefs (v0.3.0)
+            initial_dimension_beliefs: Optional initial Bayesian beliefs
 
         Returns:
             Session ID (ISO timestamp)
@@ -287,8 +287,8 @@ class QuestionFeedbackManager:
             context: Context with uncertainties before/after
             answer: Answer data (word_count, has_examples)
             reward_scores: Reward components and total
-            dimension_beliefs_before: Optional Bayesian beliefs before question (v0.3.0)
-            dimension_beliefs_after: Optional Bayesian beliefs after answer (v0.3.0)
+            dimension_beliefs_before: Optional Bayesian beliefs before question
+            dimension_beliefs_after: Optional Bayesian beliefs after answer
         """
         session = self._find_session(session_id)
         if session is None:
@@ -321,7 +321,7 @@ class QuestionFeedbackManager:
         Args:
             session_id: Session identifier
             final_uncertainties: Final uncertainty scores
-            final_dimension_beliefs: Optional final Bayesian beliefs (v0.3.0)
+            final_dimension_beliefs: Optional final Bayesian beliefs
 
         Returns:
             Session summary
@@ -388,7 +388,7 @@ class QuestionFeedbackManager:
         end_time = datetime.fromisoformat(session["completed_at"])
         session["duration_seconds"] = int((end_time - start_time).total_seconds())
         session["summary"] = summary
-        session["final_dimension_beliefs"] = final_dimension_beliefs  # v0.3.0
+        session["final_dimension_beliefs"] = final_dimension_beliefs
 
         # Update statistics
         self._update_statistics()

--- a/plugins/with-me/with_me/lib/question_reward_calculator.py
+++ b/plugins/with-me/with_me/lib/question_reward_calculator.py
@@ -158,7 +158,7 @@ def main():
             sys.exit(1)
         return
 
-    print("Question Reward Calculator v0.3.0")
+    print("Question Reward Calculator")
     print("\nAll computation has been moved to skills.")
     print("Use the following skills for reward calculation:")
     print("  - /with-me:question-clarity")


### PR DESCRIPTION
## Summary

- Bump as-you plugin version to 0.3.3 (reflects SM-2, Thompson Sampling, pattern analyzer features from #102-#104)
- Remove version numbers from documentation and code comments per `documentation-principles.md`
- Remove directory tree structure from technical-overview.md

## Changes

**as-you:**
- `plugin.json`: 0.3.2 → 0.3.3
- `help.md`: Remove version from title and description
- `technical-overview.md`: Remove directory tree (volatile info)
- `e2e/commands/help.md`: Remove version-related test assertions
- `score_calculator_hook.py`, `pattern_merger.py`, `analysis_orchestrator.py`: Remove version from comments/logs

**with-me:**
- `question_feedback_manager.py`: Remove version from docstrings/comments
- `question_reward_calculator.py`: Remove version from print output

## Test plan

- [x] `mise run test` passes
- [x] `mise run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)