### PR TITLE
docs: enforce English requirement for PR title and description

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -34,10 +34,16 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
 3. `mise run validate`
 
 **Requirements**:
-- Clear title and description
+- Clear title and description **in English**
 - All tests passing
 - No lint errors
 - Updated documentation (if applicable)
+
+**Language Rule**:
+- **CRITICAL**: PR title and description MUST be written in English
+- This is a hard requirement for GitHub collaboration
+- Never create PRs in Japanese or other languages
+- If user provides Japanese text, translate to English before creating PR
 
 **Merge strategy**: Squash and merge (preferred) for clean history
 


### PR DESCRIPTION
## Summary

Add explicit rule requiring all PR titles and descriptions to be written in English for GitHub collaboration.

## Changes

- Add **Language Rule** section to Pull Request guidelines in `.claude/rules/git-workflow.md`
- Mark English requirement as **CRITICAL**
- Add instruction to translate if user provides non-English text

## Rationale

- Ensures consistency across all pull requests
- Improves accessibility for international contributors
- Prevents confusion when reviewing PRs
- Aligns with GitHub best practices for open-source collaboration

## Example Rule

```markdown
**Language Rule**:
- **CRITICAL**: PR title and description MUST be written in English
- This is a hard requirement for GitHub collaboration
- Never create PRs in Japanese or other languages
- If user provides Japanese text, translate to English before creating PR
```

## Test plan

- [x] All pre-commit checks passed (lint, typecheck, doctest)
- [x] Rule is clear and actionable

## Checklist

- [x] Commit message follows conventional commits format
- [x] Co-Authored-By tag added
- [x] Documentation updated