### PR TITLE
Enforce PR template usage in git workflow rules

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -39,6 +39,11 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
 - No lint errors
 - Updated documentation (if applicable)
 
+**Template Rule**:
+- **CRITICAL**: Always use the PR template (`.github/PULL_REQUEST_TEMPLATE.md`)
+- Fill out all sections: Summary, Related Issues, Changes, Checklist, Testing
+- Never skip the checklist - verify each item before submitting
+
 **Language Rule**:
 - **CRITICAL**: PR title and description MUST be written in English
 - This is a hard requirement for GitHub collaboration


### PR DESCRIPTION
## Summary

Add rule to enforce PR template usage when creating pull requests.

## Related Issues

N/A

## Changes

- Add Template Rule section to `.claude/rules/git-workflow.md`
- Require filling out all PR template sections
- Require verifying checklist before submitting

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions
- [x] Doctests added for new functions
- [x] Documentation updated (if applicable)

## Testing

- Documentation-only change (Markdown)
- No functional code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)