### PR TITLE
Add GitHub Discussions rules and announcement templates

### DIFF
--- a/.claude/rules/discussions.md
+++ b/.claude/rules/discussions.md
@@ -1,0 +1,73 @@
+# GitHub Discussions
+
+## Language Rule
+
+**CRITICAL**: All discussion posts MUST be written in English.
+- This is a hard requirement for GitHub collaboration
+- Never create discussions in Japanese or other languages
+- If user provides Japanese text, translate to English before posting
+
+## Categories
+
+- **Announcements**: Updates from maintainers (project status, releases, breaking changes)
+- **Q&A**: Questions from users
+- **Ideas**: Feature suggestions and feedback
+- **Show and tell**: User showcases
+
+## Announcement Templates
+
+### Status Update
+```markdown
+Hi everyone,
+
+[Brief description of current status]
+
+**What's happening:**
+- [Item 1]
+- [Item 2]
+
+**Timeline:** [Expected duration or date]
+
+Thank you for your patience!
+
+---
+*This announcement will be updated when [condition].*
+```
+
+### Release Announcement
+```markdown
+## [Version] Released
+
+[Brief description of what's new]
+
+**Highlights:**
+- [Feature 1]
+- [Feature 2]
+
+**Breaking Changes:** [None / List]
+
+**Upgrade Guide:** [Link or instructions]
+
+See the full changelog in the PR: #[number]
+```
+
+### Maintenance Notice
+```markdown
+## Scheduled Maintenance
+
+**When:** [Date and time with timezone]
+**Duration:** [Expected duration]
+**Impact:** [What will be affected]
+
+**Details:**
+[Description of maintenance work]
+
+We apologize for any inconvenience.
+```
+
+## Best Practices
+
+- Keep announcements concise and actionable
+- Include timelines when possible
+- Update or close discussions when status changes
+- Pin important announcements


### PR DESCRIPTION
## Summary

Add rules for GitHub Discussions posts including English language requirement and announcement templates.

## Related Issues

N/A

## Changes

- Add `.claude/rules/discussions.md` with:
  - English language requirement (CRITICAL)
  - Category descriptions
  - Announcement templates (Status Update, Release, Maintenance)
  - Best practices

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions
- [x] Doctests added for new functions
- [x] Documentation updated (if applicable)

## Testing

- Documentation-only change (Markdown)
- No functional code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)