### PR TITLE
Add CLI rule for Discussion comments

### DIFF
--- a/.claude/rules/discussions.md
+++ b/.claude/rules/discussions.md
@@ -71,3 +71,29 @@ We apologize for any inconvenience.
 - Include timelines when possible
 - Update or close discussions when status changes
 - Pin important announcements
+
+## Adding Comments via CLI
+
+**CRITICAL**: Always retrieve the Discussion ID first before adding comments.
+
+```bash
+# Step 1: Get Discussion ID
+gh api graphql -f query='{
+  repository(owner: "h315uk3", name: "symbiosis") {
+    discussion(number: NUMBER) { id }
+  }
+}'
+
+# Step 2: Add comment using the retrieved ID
+gh api graphql -f query='
+mutation {
+  addDiscussionComment(input: {
+    discussionId: "RETRIEVED_ID",
+    body: "Comment content here"
+  }) {
+    comment { url }
+  }
+}'
+```
+
+Never guess or reuse Discussion IDs from previous sessions.


### PR DESCRIPTION
## Summary

Add rule requiring Discussion ID retrieval before adding comments via CLI.

## Related Issues

N/A

## Changes

- Add "Adding Comments via CLI" section to `.claude/rules/discussions.md`
- Include GraphQL command examples for ID retrieval and comment addition
- Add warning against guessing or reusing Discussion IDs

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions
- [x] Doctests added for new functions
- [x] Documentation updated (if applicable)

## Testing

- Documentation-only change (Markdown)
- No functional code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)