### PR TITLE
docs: add plugin versioning rule

### DIFF
--- a/.claude/rules/versioning.md
+++ b/.claude/rules/versioning.md
@@ -1,0 +1,115 @@
+# Versioning
+
+## Plugin Version Management
+
+### When to Bump Version
+
+**CRITICAL**: When modifying any file under `plugins/` directory, you MUST increment the plugin version in `.claude-plugin/plugin.json`.
+
+**Files that require version bump**:
+- Python code (`*.py`)
+- Command definitions (`commands/*.md`)
+- Agent definitions (`agents/*.md`)
+- Skills (`skills/*.md`)
+- Hooks (`hooks/*`)
+- Configuration schemas (`config/*.json`)
+
+**Files that DO NOT require version bump**:
+- Documentation (`docs/**/*`)
+- Contributor guides (`CONTRIBUTING.md`)
+- README files (`README.md`)
+- Manual test documentation (`tests/manual-test.md`)
+
+### Version Format
+
+Follow semantic versioning: `MAJOR.MINOR.PATCH`
+
+- **MAJOR**: Breaking changes, API incompatibilities
+- **MINOR**: New features, backward-compatible changes
+- **PATCH**: Bug fixes, minor improvements
+
+### How to Bump Version
+
+**For as-you plugin**:
+```bash
+# Edit: plugins/as-you/.claude-plugin/plugin.json
+{
+  "name": "as-you",
+  "version": "0.3.4",  # Increment this
+  ...
+}
+```
+
+**For with-me plugin**:
+```bash
+# Edit: plugins/with-me/.claude-plugin/plugin.json
+{
+  "name": "with-me",
+  "version": "0.3.5",  # Increment this
+  ...
+}
+```
+
+### Commit Message
+
+Include version bump in separate commit:
+```bash
+chore: bump plugin versions
+
+- as-you: 0.3.3 → 0.3.4
+- with-me: 0.3.4 → 0.3.5
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+```
+
+### Pull Request Requirements
+
+**Every PR that modifies plugin code MUST**:
+1. Include version bump commit
+2. Update both affected plugins
+3. Document version changes in PR description
+
+**Checklist for reviewers**:
+- [ ] Version bumped for all modified plugins
+- [ ] Semantic versioning applied correctly
+- [ ] Separate commit for version bump
+
+## Examples
+
+### Example 1: Bug Fix in as-you
+
+**Changed files**:
+- `plugins/as-you/hooks/session_start.py` (bug fix)
+
+**Required version change**:
+- as-you: `0.3.3` → `0.3.4` (PATCH bump)
+
+### Example 2: New Feature in with-me
+
+**Changed files**:
+- `plugins/with-me/commands/analyze.md` (new command)
+- `plugins/with-me/with_me/commands/analyze.py` (implementation)
+
+**Required version change**:
+- with-me: `0.3.4` → `0.4.0` (MINOR bump)
+
+### Example 3: Documentation Only
+
+**Changed files**:
+- `plugins/as-you/docs/technical-overview.md`
+- `plugins/as-you/README.md`
+
+**Required version change**:
+- None (documentation changes don't require version bump)
+
+## Rationale
+
+**Why this rule exists**:
+- Users need to know when plugins have changed
+- Version numbers communicate the nature of changes
+- Makes debugging and issue reporting easier
+- Enables proper dependency management
+
+**Enforcement**:
+- Reviewed during PR process
+- No automated enforcement (intentional - allows flexibility for docs-only PRs)


### PR DESCRIPTION
## Summary

Add comprehensive versioning guidelines to `.claude/rules/versioning.md` to ensure consistent version management across as-you and with-me plugins.

## Related Issues

N/A (proactive documentation improvement)

## Changes

### New File: `.claude/rules/versioning.md`

**Sections**:
1. **When to Bump Version**: Clear criteria for version changes
   - Files that require version bump (code, commands, agents, skills, hooks, config)
   - Files that DON'T require version bump (docs, CONTRIBUTING, README, manual-test.md)

2. **Version Format**: Semantic versioning explanation
   - MAJOR: Breaking changes
   - MINOR: New features
   - PATCH: Bug fixes

3. **How to Bump Version**: Step-by-step instructions
   - Location of version files for each plugin
   - Commit message format
   - PR requirements

4. **Examples**: Real-world scenarios
   - Bug fix in as-you (PATCH bump)
   - New feature in with-me (MINOR bump)
   - Documentation-only changes (no bump)

5. **Rationale**: Why this rule exists
   - User awareness of changes
   - Clear change communication
   - Easier debugging and issue reporting
   - Proper dependency management

### Design Decisions

**Why not automated enforcement?**
- Allows flexibility for documentation-only PRs
- Reduces friction for contributors
- Reviewed during PR process (human judgment)

**Why separate from git-workflow.md?**
- Versioning is plugin-specific, not general git workflow
- Easier to reference and update independently
- Clear separation of concerns

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions (N/A - documentation only)
- [x] Doctests added for new functions (N/A - documentation only)
- [x] Documentation updated (N/A - this IS the documentation)

## Testing

N/A - This is a documentation-only change that adds developer guidelines.

## Impact

### For Contributors
- Clear understanding when to bump plugin versions
- Consistent commit messages for version bumps
- Reduced PR review cycles (fewer "forgot to bump version" comments)

### For Users
- Better version number semantics
- Easier to understand what changed between versions
- Improved issue reporting (version numbers are meaningful)

### For Maintainers
- Standardized versioning process
- Clear criteria for review
- Documentation to reference in PR reviews

## Future Considerations

This rule provides foundation for:
- Potential automated version checking (optional future enhancement)
- Plugin changelog generation
- Dependency version management

---

**Note**: This PR adds documentation only. No version bump required per the rule itself (`.claude/rules/` is documentation).