### PR TITLE
chore: add test coverage measurement and pyright configuration

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@
 python = "3.13.11"    # Python 3.11+ required (using latest stable)
 ruff = "0.14.10"      # Python linter and formatter
 "npm:pyright" = "1.1.408"  # Python type checker (Pylance CLI)
+"pipx:coverage" = "7.6.10"  # Test coverage measurement tool
 
 # ==============================================================================
 # Development Tasks (Daily use)
@@ -49,6 +50,22 @@ run = "ruff format --check plugins/*/as_you plugins/*/with_me"
 [tasks.validate]
 description = "Validate plugin configuration files"
 run = "python3 tests/validate_plugins.py"
+
+[tasks."coverage:run"]
+description = "Run tests with coverage measurement"
+run = "coverage run tests/run_doctests.py"
+
+[tasks."coverage:report"]
+description = "Show coverage report in terminal"
+run = "coverage report"
+
+[tasks."coverage:html"]
+description = "Generate HTML coverage report"
+run = "coverage html && echo 'Report: htmlcov/index.html'"
+
+[tasks."coverage:all"]
+description = "Run coverage and show report"
+run = "mise run coverage:run && mise run coverage:report"
 
 # ==============================================================================
 # E2E Test Tasks (Manual testing verification)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,45 @@
+{
+  "include": [
+    "plugins/as-you/as_you",
+    "plugins/with-me/with_me",
+    "tests"
+  ],
+  "exclude": [
+    "**/__pycache__",
+    "**/*.pyc",
+    "**/.venv",
+    "**/venv",
+    "**/node_modules",
+    "**/.git",
+    "**/dist",
+    "**/build"
+  ],
+  "extraPaths": [
+    "plugins/as-you",
+    "plugins/with-me"
+  ],
+  "typeCheckingMode": "standard",
+  "pythonVersion": "3.11",
+  "pythonPlatform": "All",
+  "reportMissingImports": true,
+  "reportMissingTypeStubs": false,
+  "reportUnusedImport": true,
+  "reportUnusedVariable": true,
+  "reportDuplicateImport": true,
+  "reportUntypedFunctionDecorator": false,
+  "reportPrivateUsage": false,
+  "reportConstantRedefinition": true,
+  "reportIncompatibleMethodOverride": true,
+  "reportIncompatibleVariableOverride": true,
+  "reportOverlappingOverload": true,
+  "reportUnnecessaryIsInstance": true,
+  "reportUnnecessaryCast": true,
+  "reportUnnecessaryComparison": true,
+  "reportUnnecessaryContains": true,
+  "reportImplicitStringConcatenation": false,
+  "reportUnusedCallResult": false,
+  "reportUnusedCoroutine": true,
+  "reportUnusedExpression": false,
+  "reportUnnecessaryTypeIgnoreComment": true,
+  "reportMatchNotExhaustive": true
+}


### PR DESCRIPTION
## Summary

Add test coverage measurement tool and explicit pyright configuration to improve code quality and development workflow.

## Related Issues

Addresses quality improvements identified during project review.

## Changes

### Added Tools
- **coverage (7.6.10)**: Test coverage measurement tool via pipx
- **pyrightconfig.json**: Explicit type checker configuration

### Added Tasks (mise.toml)
- `mise run coverage:run` - Run tests with coverage measurement
- `mise run coverage:report` - Show coverage report in terminal
- `mise run coverage:html` - Generate HTML coverage report
- `mise run coverage:all` - Run coverage and show report (one command)

### Configuration Details
**pyrightconfig.json:**
- Includes: `plugins/as-you/as_you`, `plugins/with-me/with_me`, `tests`
- Extra paths aligned with `.vscode/settings.json`
- Type checking mode: `standard`
- Python version: `3.11`

**Current Coverage Baseline:**
- Total: 56% (3900 statements, 1734 missed)
- High coverage modules (70-89%): Core algorithms well-tested
- Low coverage modules (11-41%): CLI commands (expected - harder to doctest)

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Type checker passes (`mise run typecheck`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions (N/A - config only)
- [x] Doctests added for new functions (N/A - config only)
- [x] Documentation updated (if applicable) (N/A - internal tooling)

## Testing

```bash
# Verify coverage tool installation
mise install

# Run coverage measurement
mise run coverage:all

# Output: 56% total coverage baseline established
# All existing tests (213 doctests) pass with coverage tracking
```

## Rationale

**Why add coverage:**
- Visibility into untested code paths
- Identify missing error handling tests
- Baseline for future improvement (current: 56%)
- Positioned as quality assurance tool (similar to ruff/pyright)

**Why add pyrightconfig.json:**
- Explicit type checking configuration (no implicit defaults)
- Consistent behavior across development environments
- Aligned with existing `.vscode/settings.json` paths

**Philosophy alignment:**
Coverage and pyright are development tools (not plugin dependencies), similar to ruff. They improve code quality without affecting the "standard library only" principle for plugin code.