### PR TITLE
docs: add coverage measurement section to testing rules

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -49,6 +49,28 @@ mise run typecheck      # Type check all plugin code
 - Untyped dictionary access
 - Missing None checks for optional values
 
+## Coverage Measurement
+
+**Tool**: coverage.py
+
+**Why**: Visibility into untested code paths, identify missing error handling, track test quality over time.
+
+**Optional but recommended**: Coverage is not required for every PR, but periodic checks help maintain test quality.
+
+**Running**:
+```bash
+mise run coverage:all    # Run tests with coverage and show report
+mise run coverage:html   # Generate detailed HTML report
+```
+
+**Current Baseline**: 56% (established 2026-01-29)
+
+**Guidelines**:
+- Focus on testing critical paths and error handling
+- Don't chase 100% coverage - aim for meaningful tests
+- Use coverage to find gaps in edge case testing
+- Coverage reports help identify untested error branches and edge cases
+
 ## Interactive Testing
 
 **Manual testing required for**:


### PR DESCRIPTION
## Summary

Add documentation for coverage measurement tool in testing rules.

## Related Issues

Follow-up to #139 - documents the usage of coverage tool added in that PR.

## Changes

- Add "Coverage Measurement" section to `.claude/rules/testing.md`
- Document coverage.py commands (`coverage:all`, `coverage:html`)
- Establish baseline: 56% coverage (as of 2026-01-29)
- Clarify coverage is optional but recommended
- Provide guidelines for meaningful coverage usage

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Type checker passes (`mise run typecheck`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions (N/A - documentation only)
- [x] Doctests added for new functions (N/A - documentation only)
- [x] Documentation updated (if applicable) (✓ This PR updates documentation)

## Testing

N/A - Documentation changes only. All existing checks pass.

## Positioning

Coverage is positioned as:
- **Optional quality assurance tool** (not required for every PR)
- Similar to lint/typecheck, but used periodically
- Helps identify untested code paths and error handling gaps
- Not a goal to chase 100%, but to maintain meaningful test quality