### PR TITLE
docs: update command names from PR #142 restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,15 @@ Add notes and build knowledge:
 /as-you:learn
 ```
 
-Analyze memory and review patterns (SM-2):
+Manage patterns: analyze, review (SM-2), and promote to skills/agents:
 ```
-/as-you:memory
+/as-you:patterns
 ```
 
-Get pattern context (Thompson Sampling) or save workflows:
+Manage workflows: save procedures, view, and execute:
 ```
-/as-you:apply
-/as-you:apply "workflow-name"
+/as-you:workflows
+/as-you:workflows "workflow-name"
 ```
 
 Toggle automatic capture of prompts and edits:

--- a/plugins/as-you/README.md
+++ b/plugins/as-you/README.md
@@ -13,17 +13,19 @@ Claude: Note added
 
 [Later, in a new session...]
 
-You: /as-you:apply
-Claude: [Shows top patterns using Thompson Sampling]
-        1. Use environment variables for API keys
-        2. ...
+You: /as-you:patterns
+Claude: [Shows pattern analysis and options]
+        1. Review pattern quality (SM-2)
+        2. View top patterns
+        3. Promote to skill/agent
+        ...
 
 You: Add Stripe payment integration
 Claude: I'll implement the Stripe integration using environment variables
 for the API key, following your established pattern.
 ```
 
-> **How it works**: Patterns are presented as context when you use `/as-you:apply`. Claude considers them based on relevance to your current task. Pattern selection uses Thompson Sampling to balance proven patterns with exploration of uncertain ones.
+> **How it works**: Patterns are analyzed and scored automatically. Claude considers relevant patterns based on your current task. Pattern selection uses Thompson Sampling to balance proven patterns with exploration of uncertain ones.
 
 ---
 
@@ -41,8 +43,8 @@ for the API key, following your established pattern.
 ## Available Commands
 
 - **`/as-you:learn`** - Add notes and build knowledge from your development sessions
-- **`/as-you:memory`** - Analyze patterns, review quality, and manage your knowledge base
-- **`/as-you:apply`** - Get pattern context or save workflows for reuse
+- **`/as-you:patterns`** - Analyze patterns, review quality (SM-2), and promote to skills/agents
+- **`/as-you:workflows`** - Save, view, and execute reusable workflows
 - **`/as-you:active`** - Toggle automatic capture of prompts and file edits
 - **`/as-you:help`** - Show detailed usage documentation
 

--- a/plugins/as-you/commands/active.md
+++ b/plugins/as-you/commands/active.md
@@ -71,5 +71,5 @@ python3 -m as_you.commands.active_toggle status
 ## Related Commands
 
 - `/as-you:learn` - Add notes manually
-- `/as-you:memory` - View captured patterns
-- `/as-you:apply` - Apply learned patterns
+- `/as-you:patterns` - Analyze and manage patterns
+- `/as-you:workflows` - Manage workflows

--- a/plugins/as-you/docs/technical-overview.md
+++ b/plugins/as-you/docs/technical-overview.md
@@ -40,7 +40,7 @@ graph TD
         Bayesian[Bayesian Confidence]
         SM2[SM-2 Scheduling]
         Thompson[Thompson Sampling]
-        Apply["/as-you:apply"]
+        Apply["/as-you:workflows"]
     end
 
     Learn --> Extract
@@ -82,12 +82,12 @@ Your coding patterns are mathematically optimized for re-presentation at the rig
 
 4. Promotion Notification (Automatic)
    → Display patterns with high composite scores + confidence
-   → Viewable with /as-you:memory
+   → Viewable with /as-you:patterns
    → Thompson Sampling balances proven vs. uncertain patterns
 
 5. Knowledge Application (Manual)
-   → /as-you:apply to get pattern context
-   → /as-you:memory to promote patterns to skills/agents
+   → /as-you:workflows to manage workflows
+   → /as-you:patterns to promote patterns to skills/agents
    → Save workflows for reuse
 ```
 
@@ -102,12 +102,12 @@ Patterns are automatically extracted from your session notes using statistical i
 /as-you:learn "text"     # Add timestamped note
 /as-you:learn            # Learning dashboard (interactive)
 
-# Memory (pattern analysis + SM-2 review + confidence tracking)
-/as-you:memory           # Memory dashboard: analysis, review, promotion
+# Patterns (pattern analysis + SM-2 review + confidence tracking + promotion)
+/as-you:patterns         # Pattern dashboard: analysis, review, promotion
 
-# Apply (workflows + pattern context)
-/as-you:apply "name"     # Save workflow
-/as-you:apply            # Use patterns and workflows (interactive)
+# Workflows (save and execute procedures)
+/as-you:workflows "name" # Save workflow
+/as-you:workflows        # View and execute workflows (interactive)
 
 # Active Learning (automatic capture)
 /as-you:active on        # Enable automatic prompt and edit capture
@@ -170,7 +170,7 @@ where $r$ is the number of consecutive successful reviews (repetitions), $I_{\te
 
 **Interactive Review:**
 - Patterns are scheduled for review based on SM-2 intervals
-- Access review workflow via `/as-you:memory` → "Review pattern quality"
+- Access review workflow via `/as-you:patterns` → "Review pattern quality"
 - Quality ratings (0-5) assess pattern usefulness and update next review date
 - Low quality assessment ($q < 3$) resets: $I = 1$, $r = 0$
 
@@ -186,7 +186,7 @@ $$\theta_i \sim \text{Beta}(\alpha_i, \beta_i)$$
 
 **Usage:**
 - Thompson states are automatically updated during pattern analysis
-- Pattern selection uses Thompson Sampling via `/as-you:apply` → "Get pattern context"
+- Pattern selection uses Thompson Sampling when retrieving pattern context
 - Each pattern samples from Beta($\alpha$, $\beta$) and highest samples are selected
 - High-confidence patterns (large $\alpha$) are likely selected (exploitation)
 - Low-confidence patterns (small $\alpha + \beta$) have chances to explore

--- a/plugins/as-you/tests/manual-test.md
+++ b/plugins/as-you/tests/manual-test.md
@@ -155,7 +155,7 @@ Select: "Analyze patterns"
 
 **Expected:**
 - Displays promotion candidates with scores
-- Message about `/as-you:memory` for details
+- Message about `/as-you:patterns` for details
 - Returns to menu
 
 ---
@@ -292,14 +292,14 @@ cat .claude/as_you/active_learning.json | jq .
 
 ---
 
-## /as-you:apply
+## /as-you:workflows
 
 ### Basic: Save Workflow
 
 **Note:** Requires work history (previous tests provide enough)
 
 ```
-/as-you:apply "test-workflow"
+/as-you:workflows "test-workflow"
 ```
 
 **Expected:**
@@ -333,7 +333,7 @@ Should contain markdown sections:
 ### Edge Case: Duplicate Workflow Name
 
 ```
-/as-you:apply "test-workflow"
+/as-you:workflows "test-workflow"
 ```
 
 **Expected:** Detects duplicate, asks to overwrite or rename
@@ -343,7 +343,7 @@ Should contain markdown sections:
 ### Dashboard: Open
 
 ```
-/as-you:apply
+/as-you:workflows
 ```
 
 **Expected:**
@@ -358,7 +358,7 @@ Should contain markdown sections:
 ### Dashboard: View Workflow
 
 ```
-/as-you:apply
+/as-you:workflows
 ```
 
 Select: "View workflow" → Choose "test-workflow" → "No"
@@ -370,7 +370,7 @@ Select: "View workflow" → Choose "test-workflow" → "No"
 ### Dashboard: Execute Workflow
 
 ```
-/as-you:apply
+/as-you:workflows
 ```
 
 Select: "Execute workflow" → Choose workflow → "Execute"
@@ -388,7 +388,7 @@ Should show: usage_count incremented, last_used updated
 ### Dashboard: Get Pattern Context
 
 ```
-/as-you:apply
+/as-you:workflows
 ```
 
 Select: "Get pattern context"
@@ -404,7 +404,7 @@ Enter: "Building a REST API with authentication"
 ### Dashboard: List All Workflows
 
 ```
-/as-you:apply
+/as-you:workflows
 ```
 
 Select: "List all workflows"
@@ -416,7 +416,7 @@ Select: "List all workflows"
 ### Dashboard: Save New Workflow
 
 ```
-/as-you:apply
+/as-you:workflows
 ```
 
 Select: "Save new workflow"
@@ -446,7 +446,7 @@ Should contain: YAML frontmatter with all required fields, markdown structure
 
 Start fresh session:
 ```
-/as-you:apply "empty-workflow"
+/as-you:workflows "empty-workflow"
 ```
 
 **Expected:** Detects insufficient history, suggests adding work first
@@ -460,19 +460,19 @@ rm -rf .claude/commands/*.md
 ```
 
 ```
-/as-you:apply
+/as-you:workflows
 ```
 
 **Expected:** Shows "No workflows available", menu still offers "Save new workflow"
 
 ---
 
-## /as-you:memory
+## /as-you:patterns
 
 ### Dashboard: Open
 
 ```
-/as-you:memory
+/as-you:patterns
 ```
 
 **Expected:**
@@ -564,7 +564,7 @@ mise run test:e2e:setup:sm2-pattern
 ### SM-2 Review Execute
 
 ```
-/as-you:memory
+/as-you:patterns
 ```
 
 Select: "Review pattern quality"
@@ -593,7 +593,7 @@ rm .claude/as_you/pattern_tracker.json
 ```
 
 ```
-/as-you:memory
+/as-you:patterns
 ```
 
 **Expected:** Shows zero patterns, no errors, menu handles empty state
@@ -654,12 +654,12 @@ rm -rf .claude/commands/
 - [ ] /as-you:active - Enable/disable/status
 - [ ] /as-you:active - Capture verification
 - [ ] /as-you:active - Edge cases
-- [ ] /as-you:apply - Save workflow
-- [ ] /as-you:apply - Dashboard all menus
-- [ ] /as-you:apply - Edge cases
-- [ ] /as-you:memory - Dashboard
-- [ ] /as-you:memory - Top patterns
-- [ ] /as-you:memory - SM-2 review
+- [ ] /as-you:workflows - Save workflow
+- [ ] /as-you:workflows - Dashboard all menus
+- [ ] /as-you:workflows - Edge cases
+- [ ] /as-you:patterns - Dashboard
+- [ ] /as-you:patterns - Top patterns
+- [ ] /as-you:patterns - SM-2 review
 - [ ] /as-you:help - Display
 - [ ] All cleanup completed
 


### PR DESCRIPTION
## Summary

Follow-up documentation update for PR #142 command system restructure.

Updated all command references in documentation files to reflect the new command names:
- `/as-you:memory` → `/as-you:patterns`
- `/as-you:apply` → `/as-you:workflows`

## Related Issues

Closes follow-up task from https://github.com/h315uk3/symbiosis/pull/142#issuecomment-3827612957

## Changes

### Files Updated (5 total)

1. **README.md** (10 lines)
   - Updated usage examples in "as-you: Pattern Learning" section

2. **plugins/as-you/README.md** (16 lines)
   - Updated example workflow
   - Updated "Available Commands" section

3. **plugins/as-you/commands/active.md** (4 lines)
   - Updated "Related Commands" references

4. **plugins/as-you/docs/technical-overview.md** (22 lines)
   - Updated architecture diagram (Mermaid)
   - Updated "Automatic Learning Flow" section
   - Updated "Available Commands" section
   - Updated algorithm usage descriptions (SM-2, Thompson Sampling)

5. **plugins/as-you/tests/manual-test.md** (44 lines)
   - Updated all section headings
   - Updated all test case command references
   - Updated test completion checklist

### Verification

- [x] All markdown files checked with `grep` - no old command names remaining
- [x] All pre-commit checks passed (format, lint, typecheck, tests)
- [x] No version bump required (documentation-only changes per `.claude/rules/versioning.md`)

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my own changes
- [x] I have commented my code in hard-to-understand areas (N/A - docs only)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works (N/A - docs only)
- [x] New and existing tests pass locally
- [x] I have updated the documentation accordingly
- [x] I have checked for breaking changes (N/A - docs only)

## Testing

Documentation changes verified by:
1. Regex search confirming no old command names remain
2. All doctests passing
3. Manual review of all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)