### PR TITLE
chore: remove unsupported modelPreferences from settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,9 +17,5 @@
       "Bash(gh issue view:*)",
       "Bash(gh issue list:*)"
     ]
-  },
-  "modelPreferences": {
-    "quickTasks": "haiku",
-    "complexTasks": "sonnet"
   }
 }


### PR DESCRIPTION
## Summary

Remove unsupported `modelPreferences` configuration from `.claude/settings.json`. This field is not recognized by Claude Code and was silently ignored.

## Related Issues

None

## Changes

- Removed `modelPreferences` object with `quickTasks` and `complexTasks` properties
- This field is not part of Claude Code's official settings schema

## Background

The `modelPreferences` configuration was a custom field that Claude Code does not support. According to official documentation:

- Official model setting: `"model": "sonnet"` in settings.json
- Environment variables: `ANTHROPIC_MODEL`, etc.
- Runtime commands: `/model haiku`, `/model sonnet`

Reference: https://code.claude.com/docs/en/model-config.md

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Type checker passes (`mise run typecheck`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions (N/A - no code changes)
- [x] Doctests added for new functions (N/A - no code changes)
- [x] Documentation updated (if applicable) (N/A - removing invalid config)

## Testing

```bash
# Verify settings.json is valid JSON
cat .claude/settings.json | python3 -m json.tool

# All pre-commit checks passed during commit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)