### PR TITLE
Add asciinema recording files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ Cargo.lock
 *.rs.bk
 *.pdb
 
+# Recording files (asciinema)
+*.cast
+*.cast.bak
+
 # OS-specific files
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

Add exclusion patterns for asciinema recording files (`*.cast`, `*.cast.bak`) to prevent committing large source files to the repository.

## Related Issues

- Related to #147

## Changes

### Modified Files
- `.gitignore`: Added `*.cast` and `*.cast.bak` patterns under "Recording files (asciinema)" section

## Rationale

Asciinema recording files (`.cast`) are source files used to generate GIF animations for documentation. These files:
- Can be large (2-7MB each)
- Are intermediate artifacts, not final deliverables
- Should not be tracked in version control
- Backup files (`.cast.bak`) created during editing should also be excluded

The final GIF animations are hosted on the `gh-pages` branch for GitHub Pages.

## Checklist

- [x] Added exclusion patterns for `.cast` and `.cast.bak` files
- [x] All pre-commit checks passed (formatting, linting, type checking, tests)

## Testing

- [x] Verified `.gitignore` syntax is correct
- [x] Confirmed existing tracked files are not affected
- [x] Tested that new `.cast` files are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)