### PR TITLE
fix: correct README image URL for gh-pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Symbiosis
 
-![Symbiosis](https://h315uk3.github.io/symbiosis/docs/assets/images/banner.webp)
+![Symbiosis](https://h315uk3.github.io/symbiosis/assets/images/banner.webp)
 
 [![Python 3.11+](https://img.shields.io/badge/Python-3.11%2B-blue)](https://www.python.org/downloads/)
 [![Tests](https://github.com/h315uk3/symbiosis/actions/workflows/test.yml/badge.svg)](https://github.com/h315uk3/symbiosis/actions/workflows/test.yml)


### PR DESCRIPTION
## Summary

Fix broken banner image URL in README.md.

## Problem

GitHub Pages serves from `/docs` directory as root, so URLs should not include `/docs` prefix.

- ❌ Broken: `https://h315uk3.github.io/symbiosis/docs/assets/images/banner.webp`
- ✅ Fixed: `https://h315uk3.github.io/symbiosis/assets/images/banner.webp`

## Changes

- Modified: `README.md` (line 3) - corrected banner image URL

## Testing

Verified URL returns HTTP 200:
```
curl -I https://h315uk3.github.io/symbiosis/assets/images/banner.webp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)