### PR TITLE
fix: convert with-me demo GIF to link

### DIFF
--- a/plugins/with-me/README.md
+++ b/plugins/with-me/README.md
@@ -44,7 +44,7 @@ fast checkout. Ready to start implementation?
 
 ## Demo
 
-![Adaptive Questioning Demo](https://h315uk3.github.io/symbiosis/assets/video/demo-with-me-questions.gif)
+[▶ View Adaptive Questioning Demo](https://h315uk3.github.io/symbiosis/assets/video/demo-with-me-questions.gif)
 
 ---
 


### PR DESCRIPTION
## Summary

Convert with-me demo GIF from inline image to clickable link due to large file size.

## Problem

The `demo-with-me-questions.gif` file is 7.1 MB, which is significantly larger than other demo GIFs (1-2.6 MB) and may cause display issues in GitHub's Markdown preview.

**File sizes:**
- demo-as-you-active.gif: 1.0 MB ✓
- demo-as-you-learning.gif: 1.0 MB ✓
- demo-as-you-patterns.gif: 1.9 MB ✓
- demo-as-you-workflows.gif: 2.6 MB ✓
- demo-with-me-questions.gif: **7.1 MB** ⚠️

## Changes

- Modified: `plugins/with-me/README.md` - converted inline image to clickable link with play icon (▶)

## Testing

Verified link opens the demo GIF correctly:
https://h315uk3.github.io/symbiosis/assets/video/demo-with-me-questions.gif

🤖 Generated with [Claude Code](https://claude.com/claude-code)