### PR TITLE
fix: display with-me demo as inline image

### DIFF
--- a/plugins/with-me/README.md
+++ b/plugins/with-me/README.md
@@ -44,7 +44,7 @@ fast checkout. Ready to start implementation?
 
 ## Demo
 
-[▶ View Adaptive Questioning Demo](https://h315uk3.github.io/symbiosis/assets/video/demo-with-me-questions.gif)
+![Adaptive Questioning Demo](https://h315uk3.github.io/symbiosis/assets/video/demo-with-me-questions.gif)
 
 ---
 


### PR DESCRIPTION
## Summary

Convert with-me demo from link to inline image after successful GIF optimization.

## Background

After optimizing the GIF file size from 6.8 MB to 4.3 MB (37% reduction), the file is now small enough to display inline in GitHub's Markdown preview.

## Changes

- Modified: `plugins/with-me/README.md` - changed from link to inline image

**Before:**
```markdown
[▶ View Adaptive Questioning Demo](https://h315uk3.github.io/symbiosis/assets/video/demo-with-me-questions.gif)
```

**After:**
```markdown
![Adaptive Questioning Demo](https://h315uk3.github.io/symbiosis/assets/video/demo-with-me-questions.gif)
```

## Related

- gh-pages@ed4a993: GIF optimization commit
- Closes partial TODO from #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)