### PR TITLE
fix: persist evaluation scores via CLI for structural reliability

### DIFF
--- a/plugins/with-me/.claude-plugin/plugin.json
+++ b/plugins/with-me/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "with-me",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Collaborative development and team workflow assistant for Claude Code - You work with me (Claude)",
   "author": {
     "name": "h315uk3"

--- a/plugins/with-me/commands/good-question.md
+++ b/plugins/with-me/commands/good-question.md
@@ -334,30 +334,36 @@ python3 -m with_me.cli.session update-with-computation \
   --dimension <DIMENSION> \
   --question <QUESTION> \
   --answer <ANSWER> \
-  --likelihoods "$LIKELIHOODS"
+  --likelihoods "$LIKELIHOODS" \
+  --reward <REWARD> \
+  --eig <EIG> \
+  --clarity <CLARITY> \
+  --importance <IMPORTANCE>
 ```
+
+- `--reward`, `--eig`, `--clarity`, `--importance`: Evaluation scores from Step 2.2b. These are persisted to the session file for structural reliability.
+- For the first 2 questions (where evaluation was skipped), omit these optional flags.
 
 This command internally:
 - Calculates entropy before/after using Shannon formula
 - Performs Bayesian update (prior × likelihood, normalized)
 - Calculates information gain (H_before - H_after)
-- Persists results to session file
+- Persists results and evaluation scores to session file
 
-Output (internal use only): `status`, `entropy_before`, `entropy_after`, `information_gain`, `question_count`
+Output (internal use only): `status`, `entropy_before`, `entropy_after`, `information_gain`, `question_count`, `evaluation_scores` (if provided)
 
-**Record feedback** (after each update, using values from the output above and evaluation from Step 2.2b):
+**Record feedback** (after each update, using values from the output above):
 
 ```bash
 export PYTHONPATH="${CLAUDE_PLUGIN_ROOT}"
 python3 -m with_me.cli.feedback record <FEEDBACK_SESSION_ID> \
   <QUESTION> \
-  '{"dimension": "<DIMENSION>", "information_gain": <INFORMATION_GAIN>, "reward_scores": {"total_reward": <REWARD>, "components": {"info_gain": <EIG>, "clarity": <CLARITY>, "importance": <IMPORTANCE>}, "confidence": 1.0}}' \
+  '{"dimension": "<DIMENSION>", "information_gain": <INFORMATION_GAIN>, "reward_scores": <EVALUATION_SCORES>}' \
   '{"text": "<ANSWER>"}'
 ```
 
-- `<INFORMATION_GAIN>`: Actual info gain from `update-with-computation` output
-- `<REWARD>`, `<EIG>`, `<CLARITY>`, `<IMPORTANCE>`: Values computed in Step 2.2b evaluation
-- For the first 2 questions (where evaluation was skipped), omit `reward_scores` from the context JSON
+- `<INFORMATION_GAIN>`: From `information_gain` in `update-with-computation` output
+- `<EVALUATION_SCORES>`: From `evaluation_scores` in `update-with-computation` output (the full JSON object). If `evaluation_scores` is absent (first 2 questions), omit `reward_scores` from the context JSON.
 
 Do NOT show output to the user.
 


### PR DESCRIPTION
## Summary

Evaluation scores (reward, EIG, clarity, importance) were only held in Claude's in-context memory between the evaluate-question and feedback record steps. This PR persists them through the CLI layer to eliminate the structural risk of data loss.

## Related Issues

Follow-up to #166 (broken statistics pipeline)

## Changes

- Add optional `--reward`, `--eig`, `--clarity`, `--importance` flags to `update-with-computation` CLI command
- Persist evaluation scores to `question_history` entries in session JSON file
- Return evaluation scores in CLI JSON output for downstream consumption
- Update `good-question.md` workflow: pass evaluation scores to `update-with-computation`, read them back from output for `feedback record`

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Type checker passes (`mise run typecheck`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions
- [ ] Doctests added for new functions (CLI argparse - not doctest-suitable per testing rules)
- [x] Documentation updated (if applicable)

## Testing

- All existing doctests pass
- Lint, typecheck, and validate all pass
- The new CLI flags are optional (backward-compatible) - existing sessions continue to work without them
- Data flow: evaluate-question → update-with-computation (persists scores) → CLI output (includes scores) → feedback record (reads from output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)