### PR TITLE
fix: compute avg_reward and completed_at correctly in cmd_complete (#182)

### DIFF
--- a/plugins/with-me/.claude-plugin/plugin.json
+++ b/plugins/with-me/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "with-me",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Collaborative development and team workflow assistant for Claude Code - You work with me (Claude)",
   "author": {
     "name": "h315uk3"


### PR DESCRIPTION
## Summary

Fix two bugs in `cmd_complete` that produce incorrect session summary data.

Fixes #182

## Changes

- `avg_reward_per_question`: Compute from `evaluation_scores` in `question_history` instead of hardcoding `0`
- `completed_at`: Use `datetime.now(UTC)` instead of `args.session_id` (which is the session creation timestamp)
- Bump with-me version: 0.3.9 → 0.3.10

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Type checker passes (`mise run typecheck`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions
- [x] Doctests added for new functions
- [x] Documentation updated (if applicable)

## Testing

- Verified with existing doctests (all pass)
- Confirmed `avg_reward` computation logic: extracts `total_reward` from entries with `evaluation_scores`, computes mean, falls back to 0.0 for pre-#167 sessions without evaluation data
- Confirmed `completed_at` now uses UTC timestamp via `datetime.now(tz=UTC)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)