### PR TITLE
fix: improve evaluation score discrimination and correctness (#181)

### DIFF
--- a/plugins/with-me/.claude-plugin/plugin.json
+++ b/plugins/with-me/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "with-me",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Collaborative development and team workflow assistant for Claude Code - You work with me (Claude)",
   "author": {
     "name": "h315uk3"

--- a/plugins/with-me/with_me/cli/session.py
+++ b/plugins/with-me/with_me/cli/session.py
@@ -398,14 +398,14 @@ def cmd_evaluate_question(args: argparse.Namespace) -> None:
                 },
                 "formulas": {
                     "clarity": {
-                        "description": "Evaluate question clarity based on linguistic features",
+                        "description": "Evaluate question clarity on discriminative power and precision",
                         "criteria": [
-                            "Question mark present: +0.3",
-                            "Appropriate length (10-30 words): +0.2",
-                            "No ambiguous terms (maybe, perhaps, might): +0.2",
-                            "Single focused question (no compound or/and): +0.3",
+                            "Hypothesis targeting: Does the question distinguish between the current top 2-3 hypotheses? (0.0 generic, 0.5 partially targeting, 1.0 directly discriminating)",
+                            "Answer actionability: Would each possible answer shift beliefs meaningfully toward different hypotheses? (0.0 all answers equivalent, 0.5 some differentiation, 1.0 each answer clearly maps to different hypotheses)",
+                            "Specificity: Is the question about concrete details rather than abstract concepts? (0.0 very abstract, 0.5 moderate, 1.0 concrete and specific)",
                         ],
-                        "scale": "0.0 (unclear) to 1.0 (perfectly clear)",
+                        "formula": "CLARITY = mean of the three criteria scores",
+                        "scale": "0.0 (non-discriminative) to 1.0 (maximally discriminative)",
                     },
                     "importance": {
                         "description": "Calculate importance based on dimension weight and uncertainty",
@@ -479,14 +479,15 @@ def cmd_update_with_computation(args: argparse.Namespace) -> None:
     # Build evaluation scores if provided
     evaluation_scores: dict[str, Any] | None = None
     if args.reward is not None:
+        eig = max(0.0, args.eig) if args.eig is not None else 0.0
         evaluation_scores = {
             "total_reward": args.reward,
             "components": {
-                "info_gain": args.eig if args.eig is not None else 0.0,
+                "info_gain": eig,
                 "clarity": args.clarity if args.clarity is not None else 0.0,
                 "importance": args.importance if args.importance is not None else 0.0,
             },
-            "confidence": 1.0,
+            "confidence": hs._cached_confidence,
         }
 
     # Phase C: Persist to session history


### PR DESCRIPTION
## Summary

Fix three issues that make the question evaluation system non-discriminative.

Fixes #181

## Changes

- **confidence**: Compute from posterior concentration (`1 - H_after / H_max`) instead of hardcoding `1.0`. This reflects actual belief certainty after the update.
- **EIG clamping**: Apply `max(0.0, eig)` when building `evaluation_scores`. Negative EIG is theoretically impossible (violates Jensen's inequality) and indicates LLM estimation error.
- **clarity criteria**: Replace trivially-satisfied linguistic checks (question mark present, appropriate length, no ambiguous terms, single focused question) with discriminative criteria:
  - Hypothesis targeting: does the question distinguish between top hypotheses?
  - Answer actionability: would different answers shift beliefs toward different hypotheses?
  - Specificity: concrete details vs abstract concepts?

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Type checker passes (`mise run typecheck`)
- [x] Validation passes (`mise run validate`)
- [x] Type hints added for new functions
- [x] Doctests added for new functions
- [x] Documentation updated (if applicable)

## Testing

- All existing doctests pass
- `confidence` now uses `_cached_confidence` which is computed immediately before (line 477), guaranteed non-None
- EIG clamp is a simple `max(0.0, value)` — no behavioral change for valid EIG values
- Clarity criteria change affects LLM evaluation prompts only; no Python logic change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)