### PR TITLE
refactor: migrate session_orchestrator.py doctests to tempfile isolation

### DIFF
--- a/plugins/with-me/.claude-plugin/plugin.json
+++ b/plugins/with-me/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "with-me",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Collaborative development and team workflow assistant for Claude Code - You work with me (Claude)",
   "author": {
     "name": "h315uk3"

--- a/plugins/with-me/with_me/lib/session_orchestrator.py
+++ b/plugins/with-me/with_me/lib/session_orchestrator.py
@@ -110,9 +110,7 @@ class SessionOrchestrator:
         >>> import tempfile, shutil
         >>> from pathlib import Path
         >>> _tmp = Path(tempfile.mkdtemp())
-        >>> orch = SessionOrchestrator(
-        ...     feedback_file_path=_tmp / "feedback.json"
-        ... )
+        >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
         >>> session_id = orch.initialize_session()
 
         >>> # Main loop (simplified) - use demo mode for actual testing
@@ -196,9 +194,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> session_id = orch.initialize_session()
             >>> len(session_id) > 0
             True
@@ -242,9 +238,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> orch.record_information_gain(0.5)
             >>> orch.record_information_gain(0.3)
@@ -273,9 +267,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> # Initially not converged (uniform priors → explore phase)
             >>> orch.check_convergence()
@@ -287,9 +279,7 @@ class SessionOrchestrator:
             True
 
             >>> # All accessible dims in validate phase → converged
-            >>> orch2 = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback2.json"
-            ... )
+            >>> orch2 = SessionOrchestrator(feedback_file_path=_tmp / "feedback2.json")
             >>> _ = orch2.initialize_session()
             >>> for hs in orch2.beliefs.values():
             ...     hyps = list(hs.alpha.keys())
@@ -303,9 +293,7 @@ class SessionOrchestrator:
             True
 
             >>> # clarification_needed blocks convergence even if validate phase
-            >>> orch3 = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback3.json"
-            ... )
+            >>> orch3 = SessionOrchestrator(feedback_file_path=_tmp / "feedback3.json")
             >>> _ = orch3.initialize_session()
             >>> for hs in orch3.beliefs.values():
             ...     hyps = list(hs.alpha.keys())
@@ -367,9 +355,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> orch._get_current_kst_state()  # All uniform → empty state
             frozenset()
@@ -400,9 +386,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> accessible = orch._get_accessible_dimensions()
             >>> any(d[0] == "purpose" for d in accessible)
@@ -492,9 +476,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> dim = orch.select_next_dimension()
             >>> dim == "purpose"  # Purpose has no prerequisites
@@ -616,9 +598,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> # Successful question (high IG)
             >>> orch.update_thompson_state("purpose", 0.5)
@@ -662,9 +642,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> question = orch.generate_question("purpose")
             >>> "placeholder" in question.lower()
@@ -696,9 +674,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> dim, question = orch.select_next_question()
             >>> dim == "purpose"  # Purpose has no prerequisites
@@ -745,9 +721,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> result = orch.update_beliefs("purpose", "What?", "Web app")
             >>> "information_gain" in result
@@ -772,9 +746,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> state = orch.get_current_state()
             >>> "dimensions" in state
@@ -854,9 +826,7 @@ class SessionOrchestrator:
             >>> import tempfile, shutil
             >>> from pathlib import Path
             >>> _tmp = Path(tempfile.mkdtemp())
-            >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=_tmp / "feedback.json"
-            ... )
+            >>> orch = SessionOrchestrator(feedback_file_path=_tmp / "feedback.json")
             >>> _ = orch.initialize_session()
             >>> summary = orch.complete_session()
             >>> summary["total_questions"] == 0

--- a/plugins/with-me/with_me/lib/session_orchestrator.py
+++ b/plugins/with-me/with_me/lib/session_orchestrator.py
@@ -107,9 +107,11 @@ class SessionOrchestrator:
 
     Examples:
         >>> # Initialize orchestrator
+        >>> import tempfile, shutil
         >>> from pathlib import Path
+        >>> _tmp = Path(tempfile.mkdtemp())
         >>> orch = SessionOrchestrator(
-        ...     feedback_file_path=Path("/tmp/test_feedback.json")
+        ...     feedback_file_path=_tmp / "feedback.json"
         ... )
         >>> session_id = orch.initialize_session()
 
@@ -123,6 +125,7 @@ class SessionOrchestrator:
         >>> summary = orch.complete_session()
         >>> summary["total_questions"] == 0  # No questions asked in doctest
         True
+        >>> shutil.rmtree(_tmp)
     """
 
     def __init__(
@@ -190,13 +193,16 @@ class SessionOrchestrator:
             Session ID for tracking
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
-        >>> orch = SessionOrchestrator(
-        ...     feedback_file_path=Path("/tmp/test_feedback.json")
-        ... )
+            >>> _tmp = Path(tempfile.mkdtemp())
+            >>> orch = SessionOrchestrator(
+            ...     feedback_file_path=_tmp / "feedback.json"
+            ... )
             >>> session_id = orch.initialize_session()
             >>> len(session_id) > 0
             True
+            >>> shutil.rmtree(_tmp)
         """
         # Create default dimension beliefs (uniform priors)
         self.beliefs = create_default_dimension_beliefs()
@@ -233,15 +239,18 @@ class SessionOrchestrator:
             ig: Information gain in bits from the last question
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
+            >>> _tmp = Path(tempfile.mkdtemp())
             >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback.json")
+            ...     feedback_file_path=_tmp / "feedback.json"
             ... )
             >>> _ = orch.initialize_session()
             >>> orch.record_information_gain(0.5)
             >>> orch.record_information_gain(0.3)
             >>> len(orch.recent_information_gains)
             2
+            >>> shutil.rmtree(_tmp)
         """
         self.recent_information_gains.append(ig)
 
@@ -261,9 +270,11 @@ class SessionOrchestrator:
             True if converged, False otherwise
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
+            >>> _tmp = Path(tempfile.mkdtemp())
             >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback.json")
+            ...     feedback_file_path=_tmp / "feedback.json"
             ... )
             >>> _ = orch.initialize_session()
             >>> # Initially not converged (uniform priors → explore phase)
@@ -277,7 +288,7 @@ class SessionOrchestrator:
 
             >>> # All accessible dims in validate phase → converged
             >>> orch2 = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback2.json")
+            ...     feedback_file_path=_tmp / "feedback2.json"
             ... )
             >>> _ = orch2.initialize_session()
             >>> for hs in orch2.beliefs.values():
@@ -293,7 +304,7 @@ class SessionOrchestrator:
 
             >>> # clarification_needed blocks convergence even if validate phase
             >>> orch3 = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback3.json")
+            ...     feedback_file_path=_tmp / "feedback3.json"
             ... )
             >>> _ = orch3.initialize_session()
             >>> for hs in orch3.beliefs.values():
@@ -305,6 +316,7 @@ class SessionOrchestrator:
             >>> orch3.clarification_needed["purpose"] = True
             >>> orch3.check_convergence()
             False
+            >>> shutil.rmtree(_tmp)
         """
         # 1. Max question limit (safety fallback)
         max_questions = self.config["session_config"]["max_questions"]
@@ -352,9 +364,11 @@ class SessionOrchestrator:
             Feasible knowledge state (frozenset of resolved dimension IDs)
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
+            >>> _tmp = Path(tempfile.mkdtemp())
             >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback.json")
+            ...     feedback_file_path=_tmp / "feedback.json"
             ... )
             >>> _ = orch.initialize_session()
             >>> orch._get_current_kst_state()  # All uniform → empty state
@@ -363,6 +377,7 @@ class SessionOrchestrator:
             >>> orch.beliefs["purpose"]._cached_entropy = 0.5
             >>> sorted(orch._get_current_kst_state())
             ['purpose']
+            >>> shutil.rmtree(_tmp)
         """
         threshold = self.config["session_config"].get(
             "prerequisite_threshold_default", 1.8
@@ -382,9 +397,11 @@ class SessionOrchestrator:
             epistemic_score = epistemic_entropy / H_max, measuring reducible uncertainty.
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
+            >>> _tmp = Path(tempfile.mkdtemp())
             >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback.json")
+            ...     feedback_file_path=_tmp / "feedback.json"
             ... )
             >>> _ = orch.initialize_session()
             >>> accessible = orch._get_accessible_dimensions()
@@ -395,7 +412,7 @@ class SessionOrchestrator:
 
             >>> # With purpose resolved, dependent dimensions become accessible
             >>> orch_p = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback_p.json")
+            ...     feedback_file_path=_tmp / "feedback_p.json"
             ... )
             >>> _ = orch_p.initialize_session()
             >>> orch_p.beliefs["purpose"]._cached_entropy = 0.5
@@ -407,6 +424,7 @@ class SessionOrchestrator:
             True
             >>> "constraints" not in ids_p  # constraints requires behavior AND data
             True
+            >>> shutil.rmtree(_tmp)
         """
         current_state = self._get_current_kst_state()
         fringe = self.knowledge_space.outer_fringe(current_state)
@@ -471,9 +489,11 @@ class SessionOrchestrator:
             Dimension ID to query, or None if no accessible dimensions
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
+            >>> _tmp = Path(tempfile.mkdtemp())
             >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback.json")
+            ...     feedback_file_path=_tmp / "feedback.json"
             ... )
             >>> _ = orch.initialize_session()
             >>> dim = orch.select_next_dimension()
@@ -513,7 +533,7 @@ class SessionOrchestrator:
             >>> # Context bonus: with purpose in KST state, adjacent outer fringe dims
             >>> # (data, behavior, stakeholders) receive +0.1 per connected inner fringe dim
             >>> orch_cb = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback_cb.json")
+            ...     feedback_file_path=_tmp / "feedback_cb.json"
             ... )
             >>> _ = orch_cb.initialize_session()
             >>> orch_cb.beliefs["purpose"]._cached_entropy = 0.5  # purpose resolved
@@ -531,6 +551,7 @@ class SessionOrchestrator:
             True
             >>> len(adj["context"]) == 0  # context has no DAG edge to inner fringe
             True
+            >>> shutil.rmtree(_tmp)
         """
         accessible = self._get_accessible_dimensions()
 
@@ -592,9 +613,11 @@ class SessionOrchestrator:
             information_gain: IG in bits from the question
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
+            >>> _tmp = Path(tempfile.mkdtemp())
             >>> orch = SessionOrchestrator(
-            ...     feedback_file_path=Path("/tmp/test_feedback.json")
+            ...     feedback_file_path=_tmp / "feedback.json"
             ... )
             >>> _ = orch.initialize_session()
             >>> # Successful question (high IG)
@@ -610,6 +633,7 @@ class SessionOrchestrator:
             3.0
             >>> orch.thompson_states["purpose"]["beta"]
             2.0
+            >>> shutil.rmtree(_tmp)
         """
         epsilon = self.config["session_config"].get("diminishing_returns_epsilon", 0.05)
 
@@ -635,14 +659,17 @@ class SessionOrchestrator:
             Placeholder question text
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
-        >>> orch = SessionOrchestrator(
-        ...     feedback_file_path=Path("/tmp/test_feedback.json")
-        ... )
+            >>> _tmp = Path(tempfile.mkdtemp())
+            >>> orch = SessionOrchestrator(
+            ...     feedback_file_path=_tmp / "feedback.json"
+            ... )
             >>> _ = orch.initialize_session()
             >>> question = orch.generate_question("purpose")
             >>> "placeholder" in question.lower()
             True
+            >>> shutil.rmtree(_tmp)
         """
         # Question generation now handled by Claude in good-question.md workflow
         # See Step 2.1-2.2 for context-aware question generation
@@ -666,16 +693,19 @@ class SessionOrchestrator:
             Tuple of (dimension, question) or (None, None) if converged
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
-        >>> orch = SessionOrchestrator(
-        ...     feedback_file_path=Path("/tmp/test_feedback.json")
-        ... )
+            >>> _tmp = Path(tempfile.mkdtemp())
+            >>> orch = SessionOrchestrator(
+            ...     feedback_file_path=_tmp / "feedback.json"
+            ... )
             >>> _ = orch.initialize_session()
             >>> dim, question = orch.select_next_question()
             >>> dim == "purpose"  # Purpose has no prerequisites
             True
             >>> "placeholder" in question.lower()
             True
+            >>> shutil.rmtree(_tmp)
         """
         # Select dimension
         dimension = self.select_next_dimension()
@@ -712,14 +742,17 @@ class SessionOrchestrator:
             Dictionary with update results (stub values for demo)
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
-        >>> orch = SessionOrchestrator(
-        ...     feedback_file_path=Path("/tmp/test_feedback.json")
-        ... )
+            >>> _tmp = Path(tempfile.mkdtemp())
+            >>> orch = SessionOrchestrator(
+            ...     feedback_file_path=_tmp / "feedback.json"
+            ... )
             >>> _ = orch.initialize_session()
             >>> result = orch.update_beliefs("purpose", "What?", "Web app")
             >>> "information_gain" in result
             True
+            >>> shutil.rmtree(_tmp)
         """
         self.question_count += 1
         return {
@@ -736,14 +769,17 @@ class SessionOrchestrator:
             Dictionary with entropy, confidence, convergence status per dimension
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
-        >>> orch = SessionOrchestrator(
-        ...     feedback_file_path=Path("/tmp/test_feedback.json")
-        ... )
+            >>> _tmp = Path(tempfile.mkdtemp())
+            >>> orch = SessionOrchestrator(
+            ...     feedback_file_path=_tmp / "feedback.json"
+            ... )
             >>> _ = orch.initialize_session()
             >>> state = orch.get_current_state()
             >>> "dimensions" in state
             True
+            >>> shutil.rmtree(_tmp)
         """
         conv_threshold = self.config["session_config"]["convergence_threshold"]
         current_state = self._get_current_kst_state()
@@ -815,14 +851,17 @@ class SessionOrchestrator:
             Dictionary with session summary
 
         Examples:
+            >>> import tempfile, shutil
             >>> from pathlib import Path
-        >>> orch = SessionOrchestrator(
-        ...     feedback_file_path=Path("/tmp/test_feedback.json")
-        ... )
+            >>> _tmp = Path(tempfile.mkdtemp())
+            >>> orch = SessionOrchestrator(
+            ...     feedback_file_path=_tmp / "feedback.json"
+            ... )
             >>> _ = orch.initialize_session()
             >>> summary = orch.complete_session()
             >>> summary["total_questions"] == 0
             True
+            >>> shutil.rmtree(_tmp)
         """
         total_questions = self.question_count
         total_info_gain = sum(


### PR DESCRIPTION
## Summary

Replace all fixed `/tmp/test_feedback*.json` paths in `session_orchestrator.py` doctests with `tempfile.mkdtemp()`-based isolated paths.

## Related Issues

Closes #199

## Changes

- Replaced 17 occurrences of `Path("/tmp/test_feedback*.json")` across 13 doctest blocks with `_tmp / "feedback*.json"` using `tempfile.mkdtemp()`
- Added `import tempfile, shutil` and `_tmp = Path(tempfile.mkdtemp())` setup at the start of each block
- Added `shutil.rmtree(_tmp)` cleanup at the end of each block
- Bumped with-me version 0.7.0 → 0.7.1

## Checklist

- [x] Tests pass locally (`mise run test`)
- [x] Linter passes (`mise run lint`)
- [x] Type checker passes (`mise run typecheck`)
- [ ] Validation passes (`mise run validate`)
- [x] Type hints added for new functions
- [x] Doctests added for new functions
- [ ] Documentation updated (if applicable)

## Testing

All 13 modified doctest blocks pass. No logic changes — purely path isolation.